### PR TITLE
CORTX-28840:RGW: Add admin capabalities to rgw admin user

### DIFF
--- a/src/setup/rgw.py
+++ b/src/setup/rgw.py
@@ -292,6 +292,7 @@ class Rgw:
         rgw_config = Rgw._get_rgw_config_path(conf)
         create_usr_cmd = f'sudo radosgw-admin user create --uid={user_name} --access-key \
             {access_key} --secret {password} --display-name="{user_name}" \
+            --caps="users=*;metadata=*;usage=*;zone=*" \
             -c {rgw_config} --no-mon-config'
         _, err, rc, = SimpleProcess(create_usr_cmd).run()
         if rc == 0:


### PR DESCRIPTION
**Issue :**  Previosuly we were not assigning any capabilities to admin user creation process which was happening during rgw deployment process.
We have seen issue when CSM tries to create iam user using this admin access key it fails with "**Access Denied**" issue.
**Fix :** while creating admin user in rgw, we need to add capabilities as below,
`radosgw-admin user create --uid=admin_user --display-name="admin_user" --caps="users=*;metadata=*;usage=*;zone=*" --no-mon-config`


Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
