### PR TITLE
CORTX-28906: RGW Log rotation code Improvement

### DIFF
--- a/src/setup/rgw.py
+++ b/src/setup/rgw.py
@@ -88,8 +88,6 @@ class Rgw:
 
         except Exception as e:
             raise SetupError(errno.EINVAL, f'Error ocurred while fetching node ip, {e}')
-        Log.info(f'Configure logrotate for {COMPONENT_NAME}')
-        Rgw._logrotate_generic(conf)
 
         Log.info('Prepare phase completed.')
 
@@ -156,6 +154,8 @@ class Rgw:
                         raise SetupError(status, 'Admin user creation failed ' \
                             'with all data pods')
 
+        Log.info(f'Configure logrotate for {COMPONENT_NAME} at path: {LOGROTATE_CONF}')
+        Rgw._logrotate_generic(conf)
         Log.info('Config phase completed.')
         return 0
 
@@ -551,10 +551,9 @@ class Rgw:
         """ Configure logrotate utility for rgw logs."""
         log_dir = conf.get(LOG_PATH_KEY)
         log_file_path = os.path.join(log_dir, COMPONENT_NAME, Rgw._machine_id)
-        # rename ceph logrotate file to component's name logrotate.
+        # create radosgw logrotate file.
         # For eg:
-        # '/etc/logrotate.d/ceph' -> '/etc/logrotate.d/radosgw'
-        # currently component_name is 'rgw', file='/etc/logrotate.d/radosgw'
+        # filepath='/etc/logrotate.d/radosgw'
         old_file = os.path.join(LOGROTATE_DIR, 'ceph')
         if os.path.exists(old_file):
             os.remove(old_file)

--- a/src/setup/rgw.py
+++ b/src/setup/rgw.py
@@ -556,8 +556,8 @@ class Rgw:
         # '/etc/logrotate.d/ceph' -> '/etc/logrotate.d/radosgw'
         # currently component_name is 'rgw', file='/etc/logrotate.d/radosgw'
         old_file = os.path.join(LOGROTATE_DIR, 'ceph')
-        new_file = os.path.join(LOGROTATE_DIR, 'radosgw')
-        os.rename(old_file, new_file)
+        if os.path.exists(old_file):
+            os.remove(old_file)
         try:
             with open(LOGROTATE_TMPL, 'r') as f:
                 content = f.read()


### PR DESCRIPTION
Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
- RGW:Log Rotation: code improvement

# Design
-  Currently file '/etc/logrotate.d/ceph' is getting renamed to '/etc/logrotate.d/radosgw'
   Instead of renaming old file, creating a new file and removing old file.
   so, that in case, old file is not present, it should not impact the rest of the code.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
