### PR TITLE
CORTX-29227: RGW: support bundle should be generated even if config file is missing

### DIFF
--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -25,6 +25,7 @@ import errno
 import subprocess
 import argparse
 
+from cortx.utils.log import Log
 from cortx.utils.errors import BaseError
 from cortx.utils.process import SimpleProcess
 from cortx.utils.conf_store.conf_store import Conf, MappedConf
@@ -47,6 +48,7 @@ class RGWSupportBundle:
     @staticmethod
     def generate(bundle_id: str, target_path: str, cluster_conf: str, **filters):
         """ Generate a tar file. """
+        Log.info(f"{COMPONENT_NAME} support bundle generation started!!")
         coredumps = filters.get('coredumps', False)
         stacktrace = filters.get('stacktrace', False)
         machine_id = Conf.machine_id
@@ -63,6 +65,9 @@ class RGWSupportBundle:
         if os.path.exists(config_file):
             shutil.copyfile(config_file,\
                 os.path.join(RGWSupportBundle._tmp_src, RGW_CONF_FILE))
+        else:
+            Log.error(f"{config_file} is not present."
+                      f"Skipping the config file collection for {COMPONENT_NAME}")
 
         # copy rgw client log files
         log_dir = os.path.join(log_base, f'rgw/{machine_id}')
@@ -74,7 +79,7 @@ class RGWSupportBundle:
                     outfile = os.path.join(RGWSupportBundle._tmp_src, file)
                     shutil.copyfile(infile, outfile)
         else:
-            print("WARNING: RGW log file does not exists hence skipping log file collection.")
+            Log.error("RGW log file does not exists hence skipping log file collection.")
 
         # copy ceph crash-dump files
         if coredumps:
@@ -166,9 +171,20 @@ class RGWSupportBundle:
         else:
             raise argparse.ArgumentTypeError('Boolean value expected.')
 
+    @staticmethod
+    def initialize_logging(cluster_conf):
+        """Initialize Logging."""
+        cortx_config_store = MappedConf(cluster_conf)
+        log_path = cortx_config_store.get(LOG_PATH_KEY)
+        if log_path is None:
+            raise SupportBundleError(errno.EINVAL, 'Log path is None.')
+        log_path = os.path.join(log_path, COMPONENT_NAME, Conf.machine_id)
+        os.makedirs(log_path, exist_ok=True)
+        Log.init(f'{COMPONENT_NAME}_support_bundle', log_path)
 
 def main():
     args = RGWSupportBundle.parse_args()
+    RGWSupportBundle.initialize_logging(args.cluster_conf)
     RGWSupportBundle.generate(
         bundle_id=args.bundle_id,
         target_path=args.path,

--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -60,11 +60,9 @@ class RGWSupportBundle:
             RGWSupportBundle._cleanup()
         os.makedirs(RGWSupportBundle._tmp_src, exist_ok=True)
         # copy configuration files
-        try:
+        if os.path.exists(config_file):
             shutil.copyfile(config_file,\
                 os.path.join(RGWSupportBundle._tmp_src, RGW_CONF_FILE))
-        except FileNotFoundError as fe:
-            raise SupportBundleError(errno.ENOENT, "File not found %s", fe)
 
         # copy rgw client log files
         log_dir = os.path.join(log_base, f'rgw/{machine_id}')


### PR DESCRIPTION
Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
- According to current implementation, rgw support bundle will raise error, if config file is missing.

# Design
- support bundle should skip the config file if missing, and bundle up other log files present.

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
