### PR TITLE
CORTX-29433: RGW: Start crond service on hourly basis to enable logrotate for RGW files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ with open('README.md', 'r') as rf:
 # Get list of mini-provisioner classes
 mini_prov_files = glob.glob('./src/setup/*.py')
 logrotate_tmpl_file = 'src/rgw/setup/templates/rgw.logrotate.tmpl'
+logrotate_service_tmpl = 'src/rgw/setup/templates/logrotate.service.tmpl'
 
 setup(name='cortx-rgw-integration',
       version=rgw_intg_version,
@@ -60,6 +61,7 @@ setup(name='cortx-rgw-integration',
                     ['src/rgw/setup/rgw_setup', 'src/rgw/support/rgw_support_bundle',]),
                     ('%s/mini-provisioner' % RGW_INSTALL_PATH,['VERSION']),
                     ('%s/conf' % RGW_INSTALL_PATH,['conf/cortx_rgw.conf',
-                    logrotate_tmpl_file, 'src/rgw/support/support.yaml'])
+                    logrotate_tmpl_file, 'src/rgw/support/support.yaml',
+                    logrotate_service_tmpl])
                   ],
       )

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -27,6 +27,7 @@ CONSUL_LOCK_KEY = f'component>{COMPONENT_NAME}>volatile>{COMPONENT_NAME}_lock' #
 
 CONF_TMPL = f'{RGW_INSTALL_PATH}/conf/cortx_{COMPONENT_NAME}.conf'
 LOGROTATE_TMPL = f'{RGW_INSTALL_PATH}/conf/{COMPONENT_NAME}.logrotate.tmpl'
+CRON_LOGROTATE_TMPL = f'{RGW_INSTALL_PATH}/conf/logrotate.service.tmpl'
 # e.g CONF_TMPL will be /opt/seagate/cortx/rgw/conf/cortx_rgw.conf
 # e.g LOGROTATE_TMPL will be /opt/seagate/cortx/rgw/conf/rgw.logrotate.tmpl
 RGW_CONF_FILE = f'cortx_{COMPONENT_NAME}.conf'
@@ -34,6 +35,9 @@ SUPPORTED_BACKEND_STORES = ['motr']
 # e.g. RGW_CONFI_FILE path will be cortx_rgw.conf
 LOGROTATE_DIR = "/etc/logrotate.d"
 LOGROTATE_CONF = f'{LOGROTATE_DIR}/radosgw'
+FREQUENCY='hourly'
+CRON_DIR = f'/etc/cron.{FREQUENCY}'
+CRON_LOGROTATE = f'{CRON_DIR}/logrotate'
 CRASHDUMP_DIR = '/var/lib/ceph/crash'
 REQUIRED_RPMS = ['cortx-hare', 'cortx-py-utils', 'ceph-radosgw']
 ADMIN_PARAMETERS = {'MOTR_ADMIN_FID':'motr admin fid', 'MOTR_ADMIN_ENDPOINT':'motr admin endpoint', 'RGW_FRONTENDS': 'rgw frontends'}

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -605,6 +605,15 @@ class Rgw:
         """ Configure logrotate utility for rgw logs."""
         log_dir = conf.get(const.LOG_PATH_KEY)
         log_file_path = os.path.join(log_dir, const.COMPONENT_NAME, Rgw._machine_id)
+        # Configure the cron job on hourly frequency for RGW log files.
+        try:
+            with open(const.CRON_LOGROTATE_TMPL, 'r') as f:
+                content = f.read()
+            with open(const.CRON_LOGROTATE, 'w') as f:
+                f.write(content)
+        except Exception as e:
+            Log.error(f"Failed to configure cron job for logrotate at {const.FREQUENCY} basis."
+                      f"ERROR:{e}")
         # create radosgw logrotate file.
         # For eg:
         # filepath='/etc/logrotate.d/radosgw'
@@ -620,6 +629,12 @@ class Rgw:
             Log.info(f'{const.LOGROTATE_TMPL} file copied to {const.LOGROTATE_CONF}')
         except Exception as e:
             Log.error(f"Failed to configure logrotate for {const.COMPONENT_NAME}. ERROR:{e}")
+        # start cron.d service
+        try:
+            os.system(f"chmod +x {const.CRON_LOGROTATE}")
+            os.system("/usr/sbin/crond start")
+        except Exception as e:
+            Log.error(f"Failed to start the crond service for {const.COMPONENT_NAME}. ERROR:{e}")
 
     @staticmethod
     def _verify_backend_store_value(conf: MappedConf):

--- a/src/rgw/setup/templates/logrotate.service.tmpl
+++ b/src/rgw/setup/templates/logrotate.service.tmpl
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+/usr/sbin/logrotate /etc/logrotate.d/radosgw
+EXITVALUE=$?
+if [ $EXITVALUE != 0 ]; then
+    /usr/bin/logger -t logrotate "ALERT exited abnormally with [$EXITVALUE]"
+fi
+exit $EXITVALUE

--- a/src/rgw/setup/templates/rgw.logrotate.tmpl
+++ b/src/rgw/setup/templates/rgw.logrotate.tmpl
@@ -5,6 +5,8 @@ TMP_LOG_PATH/*.log
     weekly
     compress
     missingok
+    dateext
+    dateformat -%Y-%m-%d-%s.log
     notifempty
     copytruncate
 }


### PR DESCRIPTION
…in cortx-server pod

Signed-off-by: Palak Garg <palak.garg@seagate.com>

# Problem Statement
- RGW log files are not getting rotated in cortx-server pod

# Design
-  Enable crond service and configure logrotate for radosgw on hourly basis

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
