### PR TITLE
CORTX-29705:RGW:updation of rgw service name as rgw -> rgw_s3 in motr client & --services parameters

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -17,6 +17,7 @@
 from enum import Enum
 
 COMPONENT_NAME = 'rgw'
+COMPONENT_SVC_NAME = 'rgw_s3'
 DECRYPTION_KEY = 'cortx'
 SERVICE_NAME = f'{COMPONENT_NAME}_setup' # rgw_setup
 INSTALL_PATH = '/opt/seagate/cortx'

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -18,6 +18,9 @@ from enum import Enum
 
 COMPONENT_NAME = 'rgw'
 COMPONENT_SVC_NAME = 'rgw_s3'
+# service name be passed as --service parameter
+# e.g. rgw_setup --service={rgw_s3|all}
+SUPPORTED_SERVICE_NAMES = [COMPONENT_SVC_NAME, 'all']
 DECRYPTION_KEY = 'cortx'
 SERVICE_NAME = f'{COMPONENT_NAME}_setup' # rgw_setup
 INSTALL_PATH = '/opt/seagate/cortx'

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -18,9 +18,6 @@ from enum import Enum
 
 COMPONENT_NAME = 'rgw'
 COMPONENT_SVC_NAME = 'rgw_s3'
-# service name be passed as --service parameter
-# e.g. rgw_setup --service={rgw_s3|all}
-SUPPORTED_SERVICE_NAMES = [COMPONENT_SVC_NAME, 'all']
 DECRYPTION_KEY = 'cortx'
 SERVICE_NAME = f'{COMPONENT_NAME}_setup' # rgw_setup
 INSTALL_PATH = '/opt/seagate/cortx'

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -398,7 +398,7 @@ class Rgw:
         num_instances = 1
         while conf.get(const.CLIENT_INSTANCE_NAME_KEY % client_idx) is not None:
             name = Rgw._get_cortx_conf(conf, const.CLIENT_INSTANCE_NAME_KEY % client_idx)
-            if name == const.COMPONENT_NAME:
+            if name == const.COMPONENT_SVC_NAME:
                 num_instances = int(Rgw._get_cortx_conf(conf, const.CLIENT_INSTANCE_NUMBER_KEY % client_idx))
                 break
             client_idx = client_idx + 1

--- a/src/rgw/setup/rgw_setup
+++ b/src/rgw/setup/rgw_setup
@@ -24,7 +24,7 @@ from cortx.utils.cmd_framework import Cmd
 from cortx.utils.conf_store import Conf, MappedConf
 from cortx.rgw.setup.rgw import Rgw
 from cortx.rgw.setup.error import SetupError
-from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME, SUPPORTED_SERVICE_NAMES
+from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME
 
 class SetupCmdBase(Cmd):
     """Setup cmd base class."""
@@ -32,10 +32,13 @@ class SetupCmdBase(Cmd):
     def __init__(self, args):
         """Initialize super class members."""
         super().__init__(args)
-        # Service name mapping
+        # Service name can be passed as --service parameter
+        # e.g. rgw_setup --service={rgw_s3|all}
+        SUPPORTED_SERVICE_NAMES = [COMPONENT_SVC_NAME, 'all']
         service = args.services
         if service not in SUPPORTED_SERVICE_NAMES:
-            raise Exception("provided Service name {service} is not supported")
+            raise Exception(f'provided Service name {service} is not supported !!! \
+                Supported service names are {SUPPORTED_SERVICE_NAMES}.')
         config_url = args.config
         self._conf = MappedConf(config_url)
 

--- a/src/rgw/setup/rgw_setup
+++ b/src/rgw/setup/rgw_setup
@@ -24,7 +24,7 @@ from cortx.utils.cmd_framework import Cmd
 from cortx.utils.conf_store import Conf, MappedConf
 from cortx.rgw.setup.rgw import Rgw
 from cortx.rgw.setup.error import SetupError
-from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME
+from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME, SUPPORTED_SERVICE_NAMES
 
 class SetupCmdBase(Cmd):
     """Setup cmd base class."""
@@ -34,8 +34,8 @@ class SetupCmdBase(Cmd):
         super().__init__(args)
         # Service name mapping
         service = args.service
-        if service != COMPONENT_SVC_NAME:
-           raise Exception("provided Service name {service} is not supported")
+        if service not in SUPPORTED_SERVICE_NAMES:
+            raise Exception("provided Service name {service} is not supported")
         config_url = args.config
         self._conf = MappedConf(config_url)
 
@@ -195,7 +195,6 @@ class UpgradeCmd(SetupCmdBase):
 
 def main():
     argv = sys.argv
-
 
     try:
         desc = "CORTX Rgw Setup command"

--- a/src/rgw/setup/rgw_setup
+++ b/src/rgw/setup/rgw_setup
@@ -24,7 +24,7 @@ from cortx.utils.cmd_framework import Cmd
 from cortx.utils.conf_store import Conf, MappedConf
 from cortx.rgw.setup.rgw import Rgw
 from cortx.rgw.setup.error import SetupError
-from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME
+from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME
 
 class SetupCmdBase(Cmd):
     """Setup cmd base class."""
@@ -32,11 +32,15 @@ class SetupCmdBase(Cmd):
     def __init__(self, args):
         """Initialize super class members."""
         super().__init__(args)
+        # Service name mapping
+        service = args.service
+        if service != COMPONENT_SVC_NAME:
+           raise Exception("provided Service name {service} is not supported")
         config_url = args.config
         self._conf = MappedConf(config_url)
 
     def add_args(parser):
-        parser.add_argument('--services', default='services', help='services')
+        parser.add_argument('--services', default=COMPONENT_SVC_NAME, help='services')
         parser.add_argument('-c', '--config', default='config_url', help='config')
         parser.add_argument('--index', default='1', help='service sequence index')
 
@@ -191,6 +195,7 @@ class UpgradeCmd(SetupCmdBase):
 
 def main():
     argv = sys.argv
+
 
     try:
         desc = "CORTX Rgw Setup command"

--- a/src/rgw/setup/rgw_setup
+++ b/src/rgw/setup/rgw_setup
@@ -33,7 +33,7 @@ class SetupCmdBase(Cmd):
         """Initialize super class members."""
         super().__init__(args)
         # Service name mapping
-        service = args.service
+        service = args.services
         if service not in SUPPORTED_SERVICE_NAMES:
             raise Exception("provided Service name {service} is not supported")
         config_url = args.config


### PR DESCRIPTION
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

Refine Config Structure for RGW

MOTR clients i.e. using service names as client names, e.g. "motr_client" "rgw_s3"

RGW Mini Provisioner to be verified with "rgw_setup --service=rgw_s3" 

Reference doc : https://seagate-systems.atlassian.net/wiki/spaces/PUB/pages/611615649/CORTX+Configuration+Parameters?src=mail&src.mail.action=view&src.mail.notification=com.atlassian.confluence.plugins.confluence-notifications-batch-plugin%3Abatching-notification&src.mail.recipient=8a7f808a7812f7f70178188db13e05bf&src.mail.timestamp=1648099792383 

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
