### PR TITLE
Add --all option in support bundle to collect all logs including stacktrace, binlogs and coredumps

### DIFF
--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -157,6 +157,11 @@ class RGWSupportBundle:
             help="Include/Exclude stacktrace, Default = False")
         parser.add_argument('--modules', dest='modules',
             help="list of components & services to generate support bundle.")
+        parser.add_argument('--all', type=RGWSupportBundle.str2bool, default=False,
+            help="Include/Exclude all debug data, including logs, config, stack"
+             + " traces, core dumps, binaries, etc, possibly resulting"
+             + " in much HEAVIER support bundle, Default = False")
+
         args=parser.parse_args()
         return args
 
@@ -183,17 +188,26 @@ class RGWSupportBundle:
         Log.init(f'{COMPONENT_NAME}_support_bundle', log_path)
 
 def main():
+    import pdb;pdb.set_trace()
     args = RGWSupportBundle.parse_args()
     RGWSupportBundle.initialize_logging(args.cluster_conf)
+
+    if args.all:
+        binlogs = coredumps = stacktrace = True
+    else:
+        binlogs = args.binlogs
+        coredumps = args.coredumps
+        stacktrace = args.stacktrace
+
     RGWSupportBundle.generate(
         bundle_id=args.bundle_id,
         target_path=args.path,
         cluster_conf=args.cluster_conf,
         duration = args.duration,
         size_limit = args.size_limit,
-        binlogs = args.binlogs,
-        coredumps = args.coredumps,
-        stacktrace = args.stacktrace
+        binlogs = binlogs,
+        coredumps = coredumps,
+        stacktrace = stacktrace
     )
 
 

--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -188,7 +188,6 @@ class RGWSupportBundle:
         Log.init(f'{COMPONENT_NAME}_support_bundle', log_path)
 
 def main():
-    import pdb;pdb.set_trace()
     args = RGWSupportBundle.parse_args()
     RGWSupportBundle.initialize_logging(args.cluster_conf)
 


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

JIRA: https://jts.seagate.com/browse/CORTX-29690
# Problem Statement
- users won't be able to remember all the options of support bundle, so adding `--all`
 option to set all flags to true for collecting all logs
# Design
-  added `--all` option to collect  stacktrace, binlogs and coredumps with single option

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [x] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
