### PR TITLE
CORTX-29729:RGW:create addb stob log directory

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -111,6 +111,7 @@ SVC_LOG_FILE = f'{SVC_SECTION}>log file'
 RGW_FRONTEND_KEY = f'{SVC_SECTION}>{ADMIN_PARAMETERS["RGW_FRONTENDS"]}'
 RGW_BACKEND_STORE_KEY = 'client>rgw backend store'
 UTF_ENCODING = 'utf-8'
+MOTR_MY_FID = f'{SVC_SECTION}>motr my fid'
 
 
 class RgwEndpoint(Enum):

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -144,15 +144,26 @@ class Rgw:
 
         Log.info(f'Configure logrotate for {const.COMPONENT_NAME} at path: {const.LOGROTATE_CONF}')
         Rgw._logrotate_generic(conf)
+
         # Before starting service,Verify backend store value=motr in rgw config file.
         Rgw._verify_backend_store_value(conf)
+
+        # Create motr trace & addb stob dirctory.
+        # Collect fid value of motr to create addb value.
+        config_file = Rgw._get_rgw_config_path(conf)
+        confstore_url = const.CONFSTORE_FILE_HANDLER + config_file
+        Rgw._load_rgw_config(Rgw._conf_idx, confstore_url)
+        motr_fid_key = const.MOTR_MY_FID % index
+        motr_fid_value = Conf.get(Rgw._conf_idx, motr_fid_key)
         log_path = Rgw._get_log_dir_path(conf)
         motr_trace_dir = os.path.join(log_path, 'motr_trace_files')
+        addb_dir = os.path.join(log_path, f'addb_files-{motr_fid_value}')
         os.makedirs(motr_trace_dir, exist_ok=True)
+        os.makedirs(addb_dir, exist_ok=True)
 
         Log.info('Starting radosgw service.')
         log_file = os.path.join(log_path, f'{const.COMPONENT_NAME}_startup.log')
-        config_file = Rgw._get_rgw_config_path(conf)
+
         RgwService.start(conf, config_file, log_file, motr_trace_dir, index)
         Log.info("Started radosgw service.")
 


### PR DESCRIPTION
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

RGW mini-provisioner will create Addb logs directory as : **/etc/cortx/log/rgw/{machine-id}/addb_files-{motr fid value}/**


# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
