### PR TITLE
CORTX-29728:RGW:add 'motr enable addb = false' parameter in rgw config

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -24,7 +24,7 @@
     motr max rpc msg size = 524288
     motr reconnect interval = 4
     motr reconnect retry count = 15
-    motr addb enabled = true
+    motr addb enabled = false
 
 [client.radosgw-admin]
     motr profile fid =

--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -24,6 +24,7 @@
     motr max rpc msg size = 524288
     motr reconnect interval = 4
     motr reconnect retry count = 15
+    motr addb enabled = true
 
 [client.radosgw-admin]
     motr profile fid =

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -96,6 +96,8 @@ SVC_CONFIG_DICT['motr max idx fetch count'] = f'cortx>{COMPONENT_NAME}>motr_max_
 SVC_CONFIG_DICT['motr max rpc msg size'] = f'cortx>{COMPONENT_NAME}>motr_max_rpc_msg_size'
 SVC_CONFIG_DICT['motr reconnect interval'] = f'cortx>{COMPONENT_NAME}>motr_reconnect_interval'
 SVC_CONFIG_DICT['motr reconnect retry count'] = f'cortx>{COMPONENT_NAME}>motr_reconnect_retry_count'
+SVC_CONFIG_DICT['motr addb enabled'] = f'cortx>{COMPONENT_NAME}>motr_addb_enabled'
+
 
 SVC_DATA_PATH_CONFSTORE_KEY = f'cortx>{COMPONENT_NAME}>data_path'
 SVC_DATA_PATH_KEY = f'{COMPONENT_NAME} data path'


### PR DESCRIPTION
1. Enabling addb log generation in motr using rgw config file.
2. Currently addb dependent ticket [CORTX-29019](https://jts.seagate.com/browse/CORTX-29019) is not merged hence for our ticket , we will still introduce rgw config parameter in rgw config file during deployment but the value of that flag will be "false" instead of true.
3. once this addb dependency ticket gets merged, we will change the default value from "false" to "true" in cortx-rgw-integration repo by creating separate PR.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
