### PR TITLE
CORTX-30969:Use PVC location for storing m0trace files during mini-provisioner execution

### DIFF
--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -133,7 +133,7 @@ class Rgw:
         motr_trace_dir = os.path.join(log_path, 'motr_trace_files')
         os.makedirs(motr_trace_dir, exist_ok=True)
         os.environ['M0_TRACE_DIR'] = motr_trace_dir
-        Log.info(f'Created motr trace directory i.e. {motr_trace_dir} for collecting m0trace files.')
+        Log.info(f'Created motr trace directory : %s', os.environ['M0_TRACE_DIR'])
 
         # Read Motr HA(HAX) endpoint from data pod using hctl fetch-fids and update in config file
         # Use remote hax endpoint running on data pod which will be available during rgw

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -126,6 +126,14 @@ class Rgw:
         # Before user creation,Verify backend store value=motr in rgw config file.
         Rgw._verify_backend_store_value(conf)
 
+        # Create motr trace directory for collecting m0trace files
+        # in case admin user creation issue during mini-provisioner execution.
+        Log.info(f'Creating motr trace directory for collecting m0trace files..')
+        log_path = Rgw._get_log_dir_path(conf)
+        motr_trace_dir = os.path.join(log_path, 'motr_trace_files')
+        os.makedirs(motr_trace_dir, exist_ok=True)
+        os.environ['M0_TRACE_DIR'] = motr_trace_dir
+        Log.info(f'Created motr trace directory i.e. {motr_trace_dir} for collecting m0trace files.')
 
         # Read Motr HA(HAX) endpoint from data pod using hctl fetch-fids and update in config file
         # Use remote hax endpoint running on data pod which will be available during rgw

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -128,12 +128,12 @@ class Rgw:
 
         # Create motr trace directory for collecting m0trace files
         # in case admin user creation issue during mini-provisioner execution.
-        Log.info(f'Creating motr trace directory for collecting m0trace files..')
+        Log.info('Creating motr trace directory for collecting m0trace files..')
         log_path = Rgw._get_log_dir_path(conf)
         motr_trace_dir = os.path.join(log_path, 'motr_trace_files')
         os.makedirs(motr_trace_dir, exist_ok=True)
         os.environ['M0_TRACE_DIR'] = motr_trace_dir
-        Log.info(f'Created motr trace directory : %s', os.environ['M0_TRACE_DIR'])
+        Log.info('Created motr trace directory : %s' % os.environ.get('M0_TRACE_DIR'))
 
         # Read Motr HA(HAX) endpoint from data pod using hctl fetch-fids and update in config file
         # Use remote hax endpoint running on data pod which will be available during rgw


### PR DESCRIPTION
In case of admin user creation failure, m0trace files are created in /root directory .Hence adding the logic of mini-provisioner where m0trace files will be created in pvc location instead of /root.


Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
