### PR TITLE
change rgw concurrent request parameter

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -10,7 +10,7 @@
     rgw enable apis = s3, s3website, swift, swift_auth, admin, sts, iam, notifications
     rgw cache enabled = false
     rgw thread pool size = 10
-    rgw max concurrent request = 1024
+    rgw max concurrent request = 10
     rgw init timeout = 300
     rgw gc max objs = 32
     rgw gc obj min wait = 1800


### PR DESCRIPTION
Signed-off-by: saurabh jain <saurabh.jain2@seagate.com>

# Problem Statement
The current default value of rgw_concurrent_max_requests is set very high compared to default thread pool size.
```
rgw_concurrent_max_requests = 1024
rgw_thread_pool = 10
```
Given the limited resource availability in the VM environment and the size of threadpool in rgw server we should keep rgw_concurrent_max_requests to equal to rgw thread pool size.



# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
