### PR TITLE
CORTX-30211: added default argument for --changeset

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -31,6 +31,7 @@ CONSUL_LOCK_KEY = f'component>{COMPONENT_NAME}>volatile>{COMPONENT_NAME}_lock' #
 CLUSTER_ID_KEY = 'cluster>id'
 CONFSTORE_FILE_HANDLER = 'ini://' # confstore uses 'ini' file handler to open any config file.e.g.ini://<filepath>
 
+CHANGESET_URL = 'yaml:///etc/cortx/changeset.conf'
 CONF_TMPL = f'{RGW_INSTALL_PATH}/conf/cortx_{COMPONENT_NAME}.conf'
 LOGROTATE_TMPL = f'{RGW_INSTALL_PATH}/conf/{COMPONENT_NAME}.logrotate.tmpl'
 CRON_LOGROTATE_TMPL = f'{RGW_INSTALL_PATH}/conf/logrotate.service.tmpl'

--- a/src/rgw/setup/rgw_setup
+++ b/src/rgw/setup/rgw_setup
@@ -24,7 +24,7 @@ from cortx.utils.cmd_framework import Cmd
 from cortx.utils.conf_store import Conf, MappedConf
 from cortx.rgw.setup.rgw import Rgw
 from cortx.rgw.setup.error import SetupError
-from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME
+from cortx.rgw.const import SERVICE_NAME, LOG_PATH_KEY, COMPONENT_NAME, COMPONENT_SVC_NAME, CHANGESET_URL
 
 class SetupCmdBase(Cmd):
     """Setup cmd base class."""
@@ -46,7 +46,7 @@ class SetupCmdBase(Cmd):
         parser.add_argument('--services', default=COMPONENT_SVC_NAME, help='services')
         parser.add_argument('-c', '--config', default='config_url', help='config')
         parser.add_argument('--index', default='1', help='service sequence index')
-        parser.add_argument('--changeset', default='None', help='changeset file parameter for upgrade')
+        parser.add_argument('--changeset', default=f'{CHANGESET_URL}', help='changeset file parameter for upgrade')
 
     def _initialize_logging(self, conf: MappedConf):
         """Initialize Logging."""


### PR DESCRIPTION
Signed-off-by: Tanuja Shinde <tanuja.shinde@seagate.com>

# Problem Statement
- add default argument for --changeset in case it is not provided in mini provisioner cmd.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide


tested PR with rolling upgrade flow and upgrade mini provisioner was passed:
2022-05-30 09:05:30 cortx_setup [43]: INFO [cluster_upgrade] Starting cluster upgrade on 65b197d7f8354f58ab0668578bcc8f66:cortx-server-headless-svc-ssc-vm-rhev4-2766
2022-05-30 09:05:30 cortx_setup [43]: INFO [_provision_components] /opt/seagate/cortx/utils/bin/utils_setup upgrade --config yaml:///etc/cortx/cluster.conf --services all
2022-05-30 09:05:31 cortx_setup [43]: INFO [_provision_components] /opt/seagate/cortx/hare/bin/hare_setup upgrade --config yaml:///etc/cortx/cluster.conf --services all
2022-05-30 09:05:32 cortx_setup [43]: INFO [_provision_components] /opt/seagate/cortx/rgw/bin/rgw_setup upgrade --config yaml:///etc/cortx/cluster.conf --services rgw_s3
2022-05-30 09:05:32 cortx_setup [43]: INFO [cluster_upgrade] Finished cluster upgrade on 65b197d7f8354f58ab0668578bcc8f66:cortx-server-headless-svc-ssc-vm-rhev4-2766

