### PR TITLE
CORTX-31258:rgw-integration:Enabling rgw core file generation in PVC

### DIFF
--- a/src/rgw/setup/radosgw_start
+++ b/src/rgw/setup/radosgw_start
@@ -3,6 +3,10 @@
 INDEX=$1
 CONFIG_FILE=$2
 LOG_FILE=$3
+rgw_crash_dir=$4
+
+echo "Enable rgw core file generation at $rgw_crash_dir"
+cd $rgw_crash_dir
 
 set -o pipefail;
 /usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config 2>1 \

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -148,11 +148,14 @@ class Rgw:
         addb_dir = os.path.join(log_path, f'addb_files-{motr_fid_value}')
         os.makedirs(motr_trace_dir, exist_ok=True)
         os.makedirs(addb_dir, exist_ok=True)
+        # Create rgw crash file directory
+        rgw_crash_dir = os.path.join(log_path, 'rgw_crash')
+        os.makedirs(rgw_crash_dir, exist_ok=True)
 
         Log.info('Starting radosgw service.')
         log_file = os.path.join(log_path, f'{const.COMPONENT_NAME}_startup.log')
 
-        RgwService.start(conf, config_file, log_file, motr_trace_dir, index)
+        RgwService.start(conf, config_file, log_file, motr_trace_dir, rgw_crash_dir, index)
         Log.info("Started radosgw service.")
 
         return 0

--- a/src/rgw/setup/rgw_service.py
+++ b/src/rgw/setup/rgw_service.py
@@ -27,14 +27,14 @@ class RgwService:
     """Entrypoint class for RGW."""
 
     @staticmethod
-    def start(conf: MappedConf, config_file, log_file, motr_trace_dir, index: str = '1',):
+    def start(conf: MappedConf, config_file, log_file, motr_trace_dir, rgw_crash_dir, index: str = '1',):
         """Start rgw service independently."""
         try:
             os.environ['M0_TRACE_DIR'] = motr_trace_dir
             cmd = os.path.join(INSTALL_PATH, COMPONENT_NAME, 'bin/radosgw_start')
             sys.stdout.flush()
             sys.stderr.flush()
-            os.execl(cmd, cmd, index, config_file, log_file)
+            os.execl(cmd, cmd, index, config_file, log_file, rgw_crash_dir)
         except OSError as e:
             Log.error(f"Failed to start radosgw service:{e}")
             raise SetupError(e.errno, "Failed to start radosgw service. %s", e)


### PR DESCRIPTION
add rgw crash directory path and start rgw service from that directroy so that if any crash happens then rgw will generate core at this location.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
