### PR TITLE
CORTX-32045 : cortx-rgw-integration: fixing rpm generation issue with addb plugin binary

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -148,6 +148,7 @@ cd "$BASE_DIR"
 requirements=$(sed -z 's/\n/,/g' requirements.txt | sed -e 's/,$//')
 
 echo "%_unpackaged_files_terminate_build 0" >> ~/.rpmmacros
+echo "%_binaries_in_noarch_packages_terminate_build 0" >> ~/.rpmmacros
 
 /usr/bin/python3.6 setup.py bdist_rpm --release="$REL" --requires "$requirements"
 


### PR DESCRIPTION
On centos vm, if we enable addb plugin build, rpm build shows failure with below message,
![image](https://user-images.githubusercontent.com/65209830/172033718-e7490c73-8a1f-4003-8d7f-4d0380d7f01a.png)

To fix this, we need to set '%_binaries_in_noarch_packages_terminate_build 0' macro value.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
