### PR TITLE
CORTX-29735: Collect rgw core files as a part of rgw support bundle script

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -46,7 +46,6 @@ LOGROTATE_CONF = f'{LOGROTATE_DIR}/radosgw'
 FREQUENCY='hourly'
 CRON_DIR = f'/etc/cron.{FREQUENCY}'
 CRON_LOGROTATE = f'{CRON_DIR}/logrotate'
-CRASHDUMP_DIR = '/var/lib/ceph/crash'
 REQUIRED_RPMS = ['cortx-hare', 'cortx-py-utils', 'ceph-radosgw']
 ADMIN_PARAMETERS = {'MOTR_ADMIN_FID':'motr admin fid', 'MOTR_ADMIN_ENDPOINT':'motr admin endpoint', 'RGW_FRONTENDS': 'rgw frontends'}
 

--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -31,8 +31,7 @@ from cortx.utils.errors import BaseError
 from cortx.utils.process import SimpleProcess
 from cortx.utils.conf_store.conf_store import Conf, MappedConf
 from cortx.rgw.const import (
-    CONFIG_PATH_KEY, LOG_PATH_KEY, COMPONENT_NAME,
-    RGW_CONF_FILE, CRASHDUMP_DIR)
+    CONFIG_PATH_KEY, LOG_PATH_KEY, COMPONENT_NAME, RGW_CONF_FILE)
 
 
 class SupportBundleError(BaseError):
@@ -78,7 +77,8 @@ class RGWSupportBundle:
                 if regex.match(file):
                     infile = os.path.join(log_dir, file)
                     outfile = os.path.join(RGWSupportBundle._tmp_src, file)
-                    shutil.copyfile(infile, outfile)
+                    if os.path.isfile(infile):
+                        shutil.copyfile(infile, outfile)
         else:
             Log.error("RGW log file does not exists hence skipping log file collection.")
 
@@ -91,9 +91,10 @@ class RGWSupportBundle:
 
         # copy ceph crash-dump files
         if coredumps:
-            if os.path.exists(CRASHDUMP_DIR):
-                shutil.copytree(CRASHDUMP_DIR,\
-                    os.path.join(RGWSupportBundle._tmp_src, 'crash'))
+            crash_dump_dir = os.path.join(log_dir, 'rgw_debug')
+            if os.path.exists(crash_dump_dir):
+                shutil.copytree(crash_dump_dir,\
+                    os.path.join(RGWSupportBundle._tmp_src, 'rgw_debug'))
 
         # copy motr trace log files, if stacktrace=True
         if stacktrace:


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>
JIRA : https://jts.seagate.com/browse/CORTX-29735
# Problem Statement
- core dumps are not captured in rgw support bundle

# Design
-  CRASHDUMP path is updated
# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
