### PR TITLE
CORTX-31981: Include motr trace files in rgw support bundle by default

### DIFF
--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -89,31 +89,34 @@ class RGWSupportBundle:
             shutil.copytree(addb_dir,
                 os.path.join(RGWSupportBundle._tmp_src, addb_dir.split('/')[-1]))
 
+        # copy motr trace log files
+        motr_trace_dir = os.path.join(log_dir, 'motr_trace_files')
+        if os.path.exists(motr_trace_dir):
+            # include the latest 5 log files of motr traces in support bundle
+            list_of_files = filter(lambda f: os.path.isfile(os.path.join(motr_trace_dir, f)),
+                            os.listdir(motr_trace_dir))
+            # sort the files based on last modification time
+            list_of_files = sorted(list_of_files,
+                            key = lambda f: os.path.getmtime(os.path.join(motr_trace_dir, f)),
+                            reverse=True)
+            list_of_files = list_of_files[0:5]
+            for file in list_of_files:
+                infile = os.path.join(motr_trace_dir, file)
+                tmp_motr_trace_dir = os.path.join(RGWSupportBundle._tmp_src, 'motr_trace_files')
+                os.makedirs(tmp_motr_trace_dir, exist_ok=True)
+                outfile = os.path.join(tmp_motr_trace_dir, file)
+                shutil.copyfile(infile, outfile)
+
+        if stacktrace:
+            # TODO: CORTX-32151 Generate live stack trace for rgw process
+            pass
+
         # copy ceph crash-dump files
         if coredumps:
             crash_dump_dir = os.path.join(log_dir, 'rgw_debug')
             if os.path.exists(crash_dump_dir):
                 shutil.copytree(crash_dump_dir,\
                     os.path.join(RGWSupportBundle._tmp_src, 'rgw_debug'))
-
-        # copy motr trace log files, if stacktrace=True
-        if stacktrace:
-            motr_trace_dir = os.path.join(log_dir, 'motr_trace_files')
-            if os.path.exists(motr_trace_dir):
-                # include the latest 5 log files of motr traces in support bundle
-                list_of_files = filter(lambda f: os.path.isfile(os.path.join(motr_trace_dir, f)),
-                                os.listdir(motr_trace_dir))
-                # sort the files based on last modification time
-                list_of_files = sorted(list_of_files,
-                                key = lambda f: os.path.getmtime(os.path.join(motr_trace_dir, f)),
-                                reverse=True)
-                list_of_files = list_of_files[0:5]
-                for file in list_of_files:
-                    infile = os.path.join(motr_trace_dir, file)
-                    tmp_motr_trace_dir = os.path.join(RGWSupportBundle._tmp_src, 'motr_trace_files')
-                    os.makedirs(tmp_motr_trace_dir, exist_ok=True)
-                    outfile = os.path.join(tmp_motr_trace_dir, file)
-                    shutil.copyfile(infile, outfile)
 
         # add cortx components rpm version
         cmd = "rpm -qa | grep cortx"


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>
JIRA: https://jts.seagate.com/browse/CORTX-31981
# Problem Statement
- m0trace trace is disabled by default

# Design
-  set default behavior to always include m0trace file in support bundle and created ticket https://jts.seagate.com/browse/CORTX-32151 to generate stacktrace and add to supportbundle

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
