### PR TITLE
CORTX-31981: convert motor trace files from binary to yaml before bundling

### DIFF
--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -105,7 +105,8 @@ class RGWSupportBundle:
                 tmp_motr_trace_dir = os.path.join(RGWSupportBundle._tmp_src, 'motr_trace_files')
                 os.makedirs(tmp_motr_trace_dir, exist_ok=True)
                 outfile = os.path.join(tmp_motr_trace_dir, file)
-                shutil.copyfile(infile, outfile)
+                # Convert m0trace file to human readable yaml format
+                SimpleProcess(f'm0trace -i {infile} -Y -o {outfile}.yaml').run()
 
         if stacktrace:
             # TODO: CORTX-32151 Generate live stack trace for rgw process


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>
JIRA: https://jts.seagate.com/browse/CORTX-31981
# Problem Statement
- m0trace files are in binary format

# Design
-  converted m0trace files to yaml format using command `m0trace -i <input file> -Y -o <output file>`
# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
