### PR TITLE
fix for startup logs not visible

### DIFF
--- a/src/rgw/setup/radosgw_start
+++ b/src/rgw/setup/radosgw_start
@@ -11,6 +11,6 @@ echo "Change RGW CWD to dir $RGW_CWD, to retain core files in there"
 cd $RGW_CWD
 
 set -o pipefail;
-/usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config 2>1 \
+/usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config 2>&1 \
  | gawk '{ print strftime("[%Y-%m-%d %H:%M:%S]"), $0 }'  | tee $LOG_FILE
 exit $?


### PR DESCRIPTION
Signed-off-by: Rohit Dwivedi <rohit.k.dwivedi@seagate.com>

# Problem Statement
- rgw_startup logs not visible

# Design
-  redirection logic was 2>1 which is corrected to 2>&1
# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
