### PR TITLE
CORTX-32367:Remove hardcoded data node type value from const.py

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -69,7 +69,8 @@ AUTH_ADMIN_KEY = f'cortx>{COMPONENT_NAME}>auth_admin'
 AUTH_SECRET_KEY = f'cortx>{COMPONENT_NAME}>auth_secret'
 VERSION_KEY = 'cortx>common>release>version'
 CLUSTER_ID_KEY = 'cluster>id'
-DATA_NODE = 'data_node'
+DATA_NODE_IDENTIFIER1 = 'node'
+DATA_NODE_IDENTIFIER2 = 'num_cvg'
 
 # SSL certificate parameters
 SSL_CERT_CONFIGS = {"country" : "IN", "state" : "MH", "locality" : "Pune",

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -69,8 +69,8 @@ AUTH_ADMIN_KEY = f'cortx>{COMPONENT_NAME}>auth_admin'
 AUTH_SECRET_KEY = f'cortx>{COMPONENT_NAME}>auth_secret'
 VERSION_KEY = 'cortx>common>release>version'
 CLUSTER_ID_KEY = 'cluster>id'
-DATA_NODE_IDENTIFIER1 = 'node'
-DATA_NODE_IDENTIFIER2 = 'num_cvg'
+NODE_IDENTIFIER = 'node'
+DATA_NODE_IDENTIFIER = 'num_cvg'
 
 # SSL certificate parameters
 SSL_CERT_CONFIGS = {"country" : "IN", "state" : "MH", "locality" : "Pune",

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -704,7 +704,7 @@ class Rgw:
         data_pod_hostnames = []
         Log.info('collecting all data pod hostnames from GConf..')
         node_identify_keys = Rgw._search_cortx_conf(conf, const.NODE_IDENTIFIER, const.DATA_NODE_IDENTIFIER)
-        node_machine_ids = map(lambda x: x[0].split('>')[1], node_identify_keys)
+        node_machine_ids = list(map(lambda x: x.split('>')[1], node_identify_keys))
         for machine_id in node_machine_ids:
             data_pod_hostnames.append(Rgw._get_cortx_conf(conf, const.NODE_HOSTNAME % machine_id))
 

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -550,18 +550,13 @@ class Rgw:
         return val
 
     @staticmethod
-    def _search_cortx_conf(conf: MappedConf, parent_key: str, search_key : str, search_value = None):
+    def _search_cortx_conf(conf: MappedConf, parent_key: str, search_key : str, search_value : str = None):
         """
         Search specific key with parent level key, actual search key and optional search value.
 
         It will return list of keys.
         """
-        if search_value is None:
-           values = conf.search(parent_key, search_key)
-        else:
-           values = conf.search(parent_key, search_key, search_value)
-
-        return values
+        return conf.search(parent_key, search_key, search_value)
 
     @staticmethod
     def _get_svc_name(conf: MappedConf):
@@ -708,7 +703,7 @@ class Rgw:
         """Return all data nodes hostname from GConf"""
         data_pod_hostnames = []
         Log.info('collecting all data pod hostnames from GConf..')
-        node_identify_keys = Rgw._search_cortx_conf(conf, const.DATA_NODE_IDENTIFIER1, const.DATA_NODE_IDENTIFIER2)
+        node_identify_keys = Rgw._search_cortx_conf(conf, const.NODE_IDENTIFIER, const.DATA_NODE_IDENTIFIER)
         node_machine_ids = map(lambda x: x[0].split('>')[1], node_identify_keys)
         for machine_id in node_machine_ids:
             data_pod_hostnames.append(Rgw._get_cortx_conf(conf, const.NODE_HOSTNAME % machine_id))

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -702,13 +702,13 @@ class Rgw:
     def _get_data_nodes(conf: MappedConf):
         """Return all data nodes hostname from GConf"""
         data_pod_hostnames = []
-        Log.info('collecting all data pod hostnames from GConf..')
+        Log.debug('collecting all data pod hostnames from GConf..')
         node_identify_keys = Rgw._search_cortx_conf(conf, const.NODE_IDENTIFIER, const.DATA_NODE_IDENTIFIER)
         node_machine_ids = list(map(lambda x: x.split('>')[1], node_identify_keys))
         for machine_id in node_machine_ids:
             data_pod_hostnames.append(Rgw._get_cortx_conf(conf, const.NODE_HOSTNAME % machine_id))
 
-        Log.info(f'collected all data pod hostnames from GConf : {data_pod_hostnames}')
+        Log.debug(f'collected all data pod hostnames from GConf : {data_pod_hostnames}')
         return data_pod_hostnames
 
     @staticmethod


### PR DESCRIPTION
**Problem:**

-    In rgw mini-provisioner phase, we are fetching data pod endpoint (hostname) value using one hardcoded string "node>machine-id>type" as "data_node"
-    This hardcoded needs to be removed and data pod identification can be done with another keys.

**Solution**
-   Use Conf.search() api to identify data pods available in cluster.conf file.
-   From above list, get the hostnames of data pods. 

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [x] Side effects on other features (deployment/upgrade)
- [x] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [x] Changes done to WIKI / Confluence page / Quick Start Guide
