### PR TITLE
CORTX-32323 , CORTX_32151: generate stack trace for radsgw process and add millisec to log timestamp

### DIFF
--- a/src/rgw/setup/radosgw_start
+++ b/src/rgw/setup/radosgw_start
@@ -11,6 +11,6 @@ echo "Change RGW CWD to dir $RGW_CWD, to retain core files in there"
 cd $RGW_CWD
 
 set -o pipefail;
-/usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config 2>1 \
- | gawk '{ print strftime("[%Y-%m-%d %H:%M:%S]"), $0 }'  | tee $LOG_FILE
+/usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config 2>&1 \
+ | while read line; do printf "%s %s\n" "$(date +'[%Y-%m-%d %H:%M:%S,%03N]')" "$line"; done | tee $LOG_FILE
 exit $?

--- a/src/rgw/support/rgw_support_bundle
+++ b/src/rgw/support/rgw_support_bundle
@@ -23,7 +23,6 @@ import glob
 import shutil
 import tarfile
 import errno
-import subprocess
 import argparse
 
 from cortx.utils.log import Log
@@ -107,10 +106,25 @@ class RGWSupportBundle:
                 outfile = os.path.join(tmp_motr_trace_dir, file)
                 # Convert m0trace file to human readable yaml format
                 SimpleProcess(f'm0trace -i {infile} -Y -o {outfile}.yaml').run()
+                SimpleProcess(f'xz {outfile}.yaml').run() # compress the output file
 
         if stacktrace:
-            # TODO: CORTX-32151 Generate live stack trace for rgw process
-            pass
+            from subprocess import check_output
+            process = '/usr/bin/radosgw'
+            pid = check_output(['pidof', process]).decode('utf-8').split('\n')[0]
+            stacktrace_file = os.path.join(RGWSupportBundle._tmp_src, 'rgw_live_callstack.log')
+            # Collecting running RGW process stack trace using GDB
+            cmd = """gdb --batch --quiet -ex "thread apply all bt full" """\
+                f"""-ex "quit" {process} {pid}"""
+            Log.info(f"generating stack trace for {process} with pid {pid}")
+            output, err, _ = SimpleProcess(cmd).run()
+            with open(stacktrace_file, 'wb') as fd:
+                if output:
+                    fd.write(output)
+                else:
+                    msg = f"Failed to generate Stacktrace! {err}"
+                    Log.info(msg)
+                    fd.write(msg.encode())
 
         # copy ceph crash-dump files
         if coredumps:


### PR DESCRIPTION
Signed-off-by: rohit-k-dwivedi <rohit.k.dwivedi@seagate.com>
JIRA: [CORTX-32151](https://jts.seagate.com/browse/CORTX-32151)
also resolves the BUG: [CORTX-32323](https://jts.seagate.com/browse/CORTX-32323)
# Problem Statement
- No stack trace available for radosgw process

# Design
-  [CORTX-32151](https://jts.seagate.com/browse/CORTX-32151) : triggered `gdb --batch --quiet -ex "thread apply all bt full" -ex "quit" /usb/bin/radosgw <pid>` which sends output of bt which is written into `radosgw_bt.log` file
- [CORTX-32323](https://jts.seagate.com/browse/CORTX-32323) : along with this change, also addressed the change to add milliseconds in timestamp appending.
   as there was no way to add millis in timestamp using gawk and strftime, change logic to 
# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
