### PR TITLE
CORTX-32738: rgw: rgw support for provisioner Gconf migration to consul

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -58,10 +58,6 @@ CONFIG_PATH_KEY = 'cortx>common>storage>config'
 CLIENT_INSTANCE_NAME_KEY = 'cortx>motr>clients[%s]>name'
 CLIENT_INSTANCE_NUMBER_KEY = 'cortx>motr>clients[%s]>num_instances'
 
-CONSUL_ENDPOINT = 'cortx>external>consul'
-CONSUL_NUM_ENDPOINT_KEY = f'{CONSUL_ENDPOINT}>num_endpoints'
-CONSUL_ENDPOINT_VALUE_KEY = f'{CONSUL_ENDPOINT}>endpoint[%s]'
-
 NODE_HOSTNAME = 'node>%s>hostname'
 NODE_TYPE = 'node>%s>type'
 STORAGE_SET = 'node>%s>storage_set'
@@ -83,10 +79,13 @@ SSL_DNS_LIST = [u'*.seagate.com', u'localhost', u'*.localhost']
 SSL_CERT_PATH_KEY = 'cortx>common>security>ssl_certificate'
 
 
+CONSUL_ENDPOINT = 'cortx>external>consul'
+CONSUL_NUM_ENDPOINT_KEY = f'{CONSUL_ENDPOINT}>num_endpoints'
+CONSUL_ENDPOINT_VALUE_KEY = f'{CONSUL_ENDPOINT}>endpoints[%s]'
+
 SVC_ENDPOINT =  f'cortx>{COMPONENT_NAME}>service'
 SVC_ENDPOINT_NUM_KEY =  f'{SVC_ENDPOINT}>num_endpoints'
 SVC_ENDPOINT_VALUE_KEY = f'{SVC_ENDPOINT}>endpoints[%s]'
-
 
 # SVC additional paramters.(default value to be used in case of config key is missing in confstore.)
 # e.g. svc_keys = {'actual_svc_config_key1':'confstore_key1', 'actual_svc_config_key2':'confstore_key2'}

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -57,7 +57,11 @@ LOG_PATH_KEY = 'cortx>common>storage>log'
 CONFIG_PATH_KEY = 'cortx>common>storage>config'
 CLIENT_INSTANCE_NAME_KEY = 'cortx>motr>clients[%s]>name'
 CLIENT_INSTANCE_NUMBER_KEY = 'cortx>motr>clients[%s]>num_instances'
-CONSUL_ENDPOINT_KEY = 'cortx>external>consul>endpoints'
+
+CONSUL_ENDPOINT = 'cortx>external>consul'
+CONSUL_NUM_ENDPOINT_KEY = f'{CONSUL_ENDPOINT}>num_endpoints'
+CONSUL_ENDPOINT_VALUE_KEY = f'{CONSUL_ENDPOINT}>endpoint[%s]'
+
 NODE_HOSTNAME = 'node>%s>hostname'
 NODE_TYPE = 'node>%s>type'
 STORAGE_SET = 'node>%s>storage_set'
@@ -77,7 +81,12 @@ SSL_CERT_CONFIGS = {"country" : "IN", "state" : "MH", "locality" : "Pune",
     "organization" : "Seagate Technology", "CN" : "seagate.com", "SAN": u"*.seagate.com"}
 SSL_DNS_LIST = [u'*.seagate.com', u'localhost', u'*.localhost']
 SSL_CERT_PATH_KEY = 'cortx>common>security>ssl_certificate'
-SVC_ENDPOINT_KEY =  f'cortx>{COMPONENT_NAME}>service>endpoints'
+
+
+SVC_ENDPOINT =  f'cortx>{COMPONENT_NAME}>service'
+SVC_ENDPOINT_NUM_KEY =  f'{SVC_ENDPOINT}>num_endpoints'
+SVC_ENDPOINT_VALUE_KEY = f'{SVC_ENDPOINT}>endpoints[%s]'
+
 
 # SVC additional paramters.(default value to be used in case of config key is missing in confstore.)
 # e.g. svc_keys = {'actual_svc_config_key1':'confstore_key1', 'actual_svc_config_key2':'confstore_key2'}

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -685,7 +685,8 @@ class Rgw:
         Log.info('Checking for rgw lock in consul kv store.')
         Rgw._load_rgw_config(rgw_consul_idx, consul_url)
         rgw_lock = Rgw._get_lock(rgw_consul_idx)
-        if rgw_lock is True:
+        Log.info('Excluding user creation and hare endpoint updation')
+        #if rgw_lock is True:
             # TODO: Find a way to get current data pod hostname on server node.
             # current_data_node = socket.gethostname().replace('server', 'data')
             # user_status = Rgw._create_admin_on_current_node(conf, current_data_node)
@@ -694,7 +695,7 @@ class Rgw:
             #    Log.info(f'User creation is successful on "{Rgw._machine_id}" node.')
             #    Rgw._set_consul_kv(rgw_consul_idx, const.CONSUL_LOCK_KEY, const.ADMIN_USER_CREATED)
             # else:
-            data_pod_hostnames = Rgw._get_data_nodes(conf)
+        #    data_pod_hostnames = Rgw._get_data_nodes(conf)
             #    if len(data_pod_hostnames) == 1 and current_data_node == data_pod_hostnames[0]:
             #        Log.error('Admin user creation failed')
             #        Rgw._delete_consul_kv(rgw_consul_idx, const.CONSUL_LOCK_KEY)
@@ -702,23 +703,23 @@ class Rgw:
             #            f' "{Rgw._machine_id}" node, with all data pods - {data_pod_hostnames}')
 
             #    data_pod_hostnames.remove(current_data_node)
-            for data_pod_hostname in data_pod_hostnames:
-                try:
-                    Rgw._update_hax_endpoint(conf, data_pod_hostname)
-                except SetupError as e:
-                    Log.debug(f'Error occured while updating hax endpoints. {e}')
-                    continue
-                status = Rgw._create_rgw_user(conf)
-                if status == 0:
-                    Log.info(f'User creation is successful on "{Rgw._machine_id}" node.')
-                    Rgw._set_consul_kv(rgw_consul_idx, const.CONSUL_LOCK_KEY, const.ADMIN_USER_CREATED)
-                    break
-                else:
-                    if data_pod_hostname == data_pod_hostnames[-1]:
-                        Log.error(f'Admin user creation failed with error code - {status}')
-                        Rgw._delete_consul_kv(rgw_consul_idx, const.CONSUL_LOCK_KEY)
-                        raise SetupError(status, 'Admin user creation failed on'
-                            f' "{Rgw._machine_id}" node, with all data pods - {data_pod_hostnames}')
+        #    for data_pod_hostname in data_pod_hostnames:
+        #        try:
+        #            Rgw._update_hax_endpoint(conf, data_pod_hostname)
+        #        except SetupError as e:
+        #            Log.debug(f'Error occured while updating hax endpoints. {e}')
+        #            continue
+        #        status = Rgw._create_rgw_user(conf)
+        #        if status == 0:
+        #            Log.info(f'User creation is successful on "{Rgw._machine_id}" node.')
+        #            Rgw._set_consul_kv(rgw_consul_idx, const.CONSUL_LOCK_KEY, const.ADMIN_USER_CREATED)
+        #            break
+        #        else:
+        #            if data_pod_hostname == data_pod_hostnames[-1]:
+        #                Log.error(f'Admin user creation failed with error code - {status}')
+        #                Rgw._delete_consul_kv(rgw_consul_idx, const.CONSUL_LOCK_KEY)
+        #                raise SetupError(status, 'Admin user creation failed on'
+        #                    f' "{Rgw._machine_id}" node, with all data pods - {data_pod_hostnames}')
 
 
     @staticmethod

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -340,6 +340,13 @@ class Rgw:
     @staticmethod
     def _get_gconf_key_list(conf: MappedConf, gconf_num_key:str, actual_gconf_key:str):
         """Get value list of specified gconf key."""
+        # e.g. for single key (key - cortx>common>external>consul>endpoints), it may have multiple values as,
+        # values: [tcp://cortx-consul-server:8301, http://cortx-consul-server:8301].
+        # To get this list of values,
+        #     a) first get number of endpoints for this key using another key (cortx>common>external>consul>num_endpoints),
+        #     b) then iterate over individual key to get corresponding value with using this key & index,
+        #        e.g (cortx>common>external>consul>endpoints[0], cortx>common>external>consul>endpoints[1])
+        # this will return final list of values associated with given gconf key.
         Log.info(f'Fetching gconf num_key from Gconf: {gconf_num_key}')
         num_of_keys = int(Rgw._get_cortx_conf(conf, gconf_num_key))
         Log.info(f'Found number of keys:{num_of_keys}')

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -520,11 +520,8 @@ class Rgw:
             endpoint = Rgw._get_cortx_conf(conf, const.SVC_ENDPOINT_VALUE_KEY % ep_index)
             svc_endpoints.append(endpoint)
 
-
-        endpoints = conf.get(const.SVC_ENDPOINT_KEY)
-        if endpoints:
-            svc_endpoints = list(filter(lambda x: urlparse(x).scheme == protocol, endpoints))
-            port = urlparse(svc_endpoints[0]).port
+            svc_ep = list(filter(lambda x: urlparse(x).scheme == protocol, svc_endpoints))
+            port = urlparse(svc_ep[0]).port
             Log.info(f'{protocol} port value - {port}')
         else:
             # If endpoint is not present, use default port value.
@@ -532,7 +529,7 @@ class Rgw:
                 port = const.DEFAULT_HTTP_PORT
             elif protocol == 'https':
                 port = const.DEFAULT_HTTPS_PORT
-            Log.info(f'{const.SVC_ENDPOINT_KEY} is not available in cluster.conf,'
+            Log.info(f'{const.SVC_ENDPOINT_NUM_KEY} is not available in cluster.conf,'
                 f' using the default value. {protocol} - {port}')
         return port
 

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -101,11 +101,9 @@ class Rgw:
         if not os.path.exists(config_file):
             raise SetupError(errno.EINVAL, f'"{config_file}" config file is not present.')
 
-        Log.info('Generating SSL certs')
         # Create ssl certificate
         Rgw._generate_ssl_cert(conf)
 
-        Log.info('Creating svc config')
         # Create svc config
         Rgw._create_svc_config(conf)
 
@@ -126,7 +124,6 @@ class Rgw:
         # config phase since data pod starts before server pod.
         # Try HAX endpoint from data pod of same node first & if it doesnt work,
         # from other data pods in cluster
-        Log.info('updating hax endpoint and creating admin user')
         Rgw._update_hax_endpoint_and_create_admin(conf)
         Log.info('Config phase completed.')
 
@@ -278,12 +275,9 @@ class Rgw:
     @staticmethod
     def _create_svc_config(conf: MappedConf):
         """Create svc config"""
-        Log.info('creating svc config file..')
         svc_name = Rgw._get_svc_name(conf)
-        Log.info(f'got svc name:{svc_name}')
 
         client_instance_count = Rgw._get_num_client_instances(conf, svc_name)
-        Log.info(f'got client instance count:{client_instance_count}')
         Log.info('fetching endpoint values from hctl fetch-fids cmd.')
         # For running rgw service and radosgw-admin tool,
         # we are using same endpoints fetched from hctl fetch-fids cmd as default endpoints,
@@ -292,30 +286,22 @@ class Rgw:
         # Update motr fid,endpoint config in cortx_rgw.conf.
         instance = 1
         while instance <= client_instance_count:
-            Log.info(f'Parsing endpoint value for instance: {instance}')
             service_endpoints = Rgw._parse_endpoint_values(
                 conf, instance, client_instance_count, svc_name)
-            Log.info(f'Validating endpoint entries provided by fetch-fids cmd:{service_endpoints}')
             Rgw._validate_endpoint_paramters(service_endpoints)
-            Log.info('Validated endpoint entries provided by fetch-fids cmd successfully.')
 
-            Log.info('Updating endpoint values in rgw config file.')
             Rgw._update_rgw_config_with_endpoints(conf, service_endpoints, instance)
             instance = instance + 1
 
         # Add additional parameters of SVC & Motr to config file.
-        Log.info('Updating rgw config with svc config')
         Rgw._update_svc_config(conf, 'client', const.SVC_CONFIG_DICT)
-        Log.info('Updating rgw config with data path ')
         Rgw._update_svc_data_path_value(conf, 'client')
 
         # Before user creation,Verify backend store value=motr in rgw config file.
-        Log.info('Verifying backendstore value')
         Rgw._verify_backend_store_value(conf)
 
         Log.info(f'Configure logrotate for {const.COMPONENT_NAME} at path: {const.LOGROTATE_CONF}')
         Rgw._logrotate_generic(conf)
-        Log.info('Done with log rotate logic')
 
     @staticmethod
     def _get_consul_url(conf: MappedConf, seq: int = 0):
@@ -347,33 +333,26 @@ class Rgw:
         #     b) then iterate over individual key to get corresponding value with using this key & index,
         #        e.g (cortx>common>external>consul>endpoints[0], cortx>common>external>consul>endpoints[1])
         # this will return final list of values associated with given gconf key.
-        Log.info(f'Fetching gconf num_key from Gconf: {gconf_num_key}')
         num_of_keys = int(Rgw._get_cortx_conf(conf, gconf_num_key))
-        Log.info(f'Found number of keys:{num_of_keys}')
         if num_of_keys == 0:
             raise SetupError(errno.EINVAL, f"Invalid/Missing values found in gconf for key :'{gconf_num_key}'")
         value_list = []
         for value_index in range(0, num_of_keys):
             key_value = Rgw._get_cortx_conf(conf, actual_gconf_key % value_index)
             value_list.append(key_value)
-        Log.info(f'Returing value list: {value_list}')
         return value_list
 
     @staticmethod
     def _fetch_consul_endpoint_url(conf: MappedConf, endpoint_type: str):
         """Fetch endpoint url based on endpoint type from cortx config."""
-        Log.info('Fetching consul endpoint url using new gconf method.')
         consul_endpoints = Rgw._get_gconf_key_list(conf, const.CONSUL_NUM_ENDPOINT_KEY,
                                                    const.CONSUL_ENDPOINT_VALUE_KEY)
-        Log.info(f'got all consul_endpoints :{consul_endpoints}')
         endpoints_value = list(filter(lambda x: urlparse(x).scheme == endpoint_type,
                                       consul_endpoints))
-        Log.info(f'got required endpoint value:{endpoints_value}')
         if len(endpoints_value) == 0:
             raise SetupError(errno.EINVAL,
                 f'{endpoint_type} endpoint is not specified in the conf.'
                 f' Listed endpoints: {consul_endpoints}')
-        Log.info(f'Returning final consul endpoint value :{endpoints_value}')
         return endpoints_value
 
     @staticmethod
@@ -543,15 +522,11 @@ class Rgw:
     def _get_service_port(conf: MappedConf, protocol: str):
         """Return rgw service port value."""
         port = None
-        Log.info('Fetching service port using new Gconf method.')
         svc_endpoints = Rgw._get_gconf_key_list(conf, const.SVC_ENDPOINT_NUM_KEY,
                                                    const.SVC_ENDPOINT_VALUE_KEY)
-        Log.info(f'got all svc endpoints :{svc_endpoints}')
         if len(svc_endpoints) > 0 :
             svc_ep = list(filter(lambda x: urlparse(x).scheme == protocol, svc_endpoints))
-            Log.info(f'got expected endpoint :{svc_ep}')
             port = urlparse(svc_ep[0]).port
-            Log.info(f'{protocol} port value - {port}')
         else:
             # If endpoint is not present, use default port value.
             if protocol == 'http':

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -341,7 +341,7 @@ class Rgw:
     def _get_gconf_key_list(conf: MappedConf, gconf_num_key:str, actual_gconf_key:str):
         """Get value list of specified gconf key."""
         Log.info(f'Fetching gconf num_key from Gconf: {gconf_num_key}')
-        num_of_keys = Rgw._get_cortx_conf(conf, gconf_num_key)
+        num_of_keys = int(Rgw._get_cortx_conf(conf, gconf_num_key))
         Log.info(f'Found number of keys:{num_of_keys}')
         if num_of_keys == 0:
             raise SetupError(errno.EINVAL, f"Invalid/Missing values found in gconf for key :'{gconf_num_key}'")
@@ -621,7 +621,7 @@ class Rgw:
     def _get_svc_name(conf: MappedConf):
         """Read service name from cluster.conf"""
         svc_name = None
-        num_component = Rgw._get_cortx_conf(conf, const.NUM_COMPONENTS_KEY % Rgw._machine_id)
+        num_component = int(Rgw._get_cortx_conf(conf, const.NUM_COMPONENTS_KEY % Rgw._machine_id))
         for idx in range(0, num_component):
             if (Rgw._get_cortx_conf(conf,
                 const.COMPONENT_NAME_KEY % (Rgw._machine_id, idx)) == const.COMPONENT_NAME):

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -329,7 +329,7 @@ class Rgw:
     @staticmethod
     def _get_gconf_key_list(conf: MappedConf, gconf_num_key:str, actual_gconf_key:str):
         """Get value list of specified gconf key."""
-        num_of_keys = int(Rgw._get_cortx_conf(conf, gconf_num_key))
+        num_of_keys = Rgw._get_cortx_conf(conf, gconf_num_key)
         if num_of_keys == 0:
             raise SetupError(errno.EINVAL, f"Invalid/Missing values found in gconf for key :'{gconf_num_key}'")
         value_list = []

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -542,7 +542,7 @@ class Rgw:
         Log.info(f'got all svc endpoints :{svc_endpoints}')
         if len(svc_endpoints) > 0 :
             svc_ep = list(filter(lambda x: urlparse(x).scheme == protocol, svc_endpoints))
-            Log.info(f'{got expected endpoint :{svc_ep}}')
+            Log.info(f'got expected endpoint :{svc_ep}')
             port = urlparse(svc_ep[0]).port
             Log.info(f'{protocol} port value - {port}')
         else:


### PR DESCRIPTION
Problem:
Provisioner team is planning to migrate file based Gconf to consule based Gconf.
In order to do this, rgw component needs some changes to support this migration. 

Solution:
There are changes required in way we fetch the endpoints values from Gconf e.g. consul endpoint, service endpoint ports.
Approach we took is,  
   a) for any key we want to fetch, first  we need to fetch num_client/num_endpoints key from Gconf.
   b) based on this number, we need to iterate over each key and get desired value of key.


Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
