### PR TITLE
CORTX-33543:rgw-integration:collect radosadmin cli core files

### DIFF
--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -116,23 +116,18 @@ class Rgw:
         os.environ['M0_TRACE_DIR'] = motr_trace_dir
         Log.info('Created motr trace directory : %s' % os.environ.get('M0_TRACE_DIR'))
 
+        # Change current working directory to rgw_debug for core file generation
+        RGW._change_working_dir(conf)
+
         # Read Motr HA(HAX) endpoint from data pod using hctl fetch-fids and update in config file
         # Use remote hax endpoint running on data pod which will be available during rgw
         # config phase since data pod starts before server pod.
         # Try HAX endpoint from data pod of same node first & if it doesnt work,
         # from other data pods in cluster
 
-        log_path = Rgw._get_log_dir_path(conf)
-        # Create rgw crash file directory
-        rgw_core_dir = os.path.join(log_path, 'rgw_debug')
-        os.makedirs(rgw_core_dir, exist_ok=True)
-
-        cwd = os.getcwd()
-        os.chdir(rgw_core_dir)
         Rgw._update_hax_endpoint_and_create_admin(conf)
         Log.info('Config phase completed.')
 
-        os.chdir(cwd)
 
         return 0
 
@@ -382,6 +377,15 @@ class Rgw:
         log_dir_path = os.path.join(log_path, const.COMPONENT_NAME, Rgw._machine_id)
         os.makedirs(log_dir_path, exist_ok=True)
         return log_dir_path
+
+    @staticmethod
+    def _change_working_dir(conf: MappedConf):
+        """Change current working directory to crash directory path."""
+        log_path = Rgw._get_log_dir_path(conf)
+        # Create svc crash file directory
+        svc_core_dir = os.path.join(log_path, 'rgw_debug')
+        os.makedirs(svc_core_dir, exist_ok=True)
+        os.chdir(svc_core_dir)
 
     @staticmethod
     def _create_rgw_user(conf: MappedConf):

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -121,8 +121,18 @@ class Rgw:
         # config phase since data pod starts before server pod.
         # Try HAX endpoint from data pod of same node first & if it doesnt work,
         # from other data pods in cluster
+
+        log_path = Rgw._get_log_dir_path(conf)
+        # Create rgw crash file directory
+        rgw_core_dir = os.path.join(log_path, 'rgw_debug')
+        os.makedirs(rgw_core_dir, exist_ok=True)
+
+        cwd = os.getcwd()
+        os.chdir(rgw_core_dir)
         Rgw._update_hax_endpoint_and_create_admin(conf)
         Log.info('Config phase completed.')
+
+        os.chdir(cwd)
 
         return 0
 

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -117,7 +117,7 @@ class Rgw:
         Log.info('Created motr trace directory : %s' % os.environ.get('M0_TRACE_DIR'))
 
         # Change current working directory to rgw_debug for core file generation
-        RGW._change_working_dir(conf)
+        Rgw._change_working_dir(conf)
 
         # Read Motr HA(HAX) endpoint from data pod using hctl fetch-fids and update in config file
         # Use remote hax endpoint running on data pod which will be available during rgw


### PR DESCRIPTION
Problem : 
During debugging of https://jts.seagate.com/browse/CORTX-33293, we saw when rgw mini-provisioner tries to create admin user in multi data pod environment,, it crashes in motr and result into radosadmin cli crash.
For this crash we did not see any core files generated for rgw .

solution:
change the working directory to pvc path and then try to create user.

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
