### PR TITLE
CORTX-30240: Log to both stderr and file for k8s environments

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -45,3 +45,6 @@
     motr my fid       =
     rgw frontends = beast port=8000
     log file =
+    log to file = true
+    log to stderr = true
+    err to stderr = true


### PR DESCRIPTION
# Problem Statement
As part of [F-58D](https://jts.seagate.com/browse/CORTX-29950), all CORTX components are updating their logging setups to support both log files and stderr output. This is important for Kubernetes environments, where logs should be accessible via `kubectl logs`. Currently, RGW server only sends its logs to a file.

# Design
RGW supports logging to both file and stderr simultaneously. This PR adds a few logging-related options to the RGW config template to log to both locations. The existing log file setup is not changed, this PR just tees log messages to stderr as well. Full details on RGW logging config are available [here](https://docs.ceph.com/en/quincy/rados/troubleshooting/log-and-debug/#logging-settings).

I tested out deployment with these options, and found the same log messages in both `rgw-1.log` and in the output of `kubectl logs`.

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
