### PR TITLE
CORTX-30014:Remove hardcoding of python3.6 from build.sh file

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -150,7 +150,7 @@ requirements=$(sed -z 's/\n/,/g' requirements.txt | sed -e 's/,$//')
 echo "%_unpackaged_files_terminate_build 0" >> ~/.rpmmacros
 echo "%_binaries_in_noarch_packages_terminate_build 0" >> ~/.rpmmacros
 
-/usr/bin/python3.6 setup.py bdist_rpm --release="$REL" --requires "$requirements"
+python3 setup.py bdist_rpm --release="$REL" --requires "$requirements"
 
 if [ $? -ne 0 ]; then
   echo "ERROR !!! cortx-rgw-integration rpm build failed !!!"


### PR DESCRIPTION
In build.sh file, we hardcoded python3.6 binary path.
Hence removed this hardcoding and used python3 which is symbolic link of python3.6 
Tomorrow if we plan to upgrade python version then our code will still work.


Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [x] Unit and System Tests are added
- [x] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
