### PR TITLE
CORTX-32172: Fixes ADDB client logs to bundled it in rgw support bundle

### DIFF
--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -117,6 +117,17 @@ class Rgw:
         os.environ['M0_TRACE_DIR'] = motr_trace_dir
         Log.info('Created motr trace directory : %s' % os.environ.get('M0_TRACE_DIR'))
 
+        # Create motr addb directory for collecting addb files
+        # in case admin user creation issue during mini-provisioner execution.
+        Log.info('Creating motr addb_files- directory for collecting addb files..')
+        motr_fid_key = const.MOTR_ADMIN_FID_KEY
+        motr_fid_value = Conf.get(Rgw._conf_idx, motr_fid_key)
+        log_path = Rgw._get_log_dir_path(conf)
+        addb_dir = os.path.join(log_path, f'addb_files-{motr_fid_value}')
+        os.makedirs(addb_dir, exist_ok=True)
+        os.environ['M0_CLIENT_ADDB_DIR'] = addb_dir
+        Log.info('Created addb-files- directory : %s' % os.environ.get('M0_CLIENT_ADDB_DIR'))
+
         # Change current working directory to rgw_debug for core file generation
         Rgw._change_working_dir(conf)
 
@@ -147,9 +158,11 @@ class Rgw:
         motr_fid_value = Conf.get(Rgw._conf_idx, motr_fid_key)
         log_path = Rgw._get_log_dir_path(conf)
         motr_trace_dir = os.path.join(log_path, 'motr_trace_files')
-        addb_dir = os.path.join(log_path, f'addb_files-{motr_fid_value}')
         os.makedirs(motr_trace_dir, exist_ok=True)
+
+        addb_dir = os.path.join(log_path, f'addb_files-{motr_fid_value}')
         os.makedirs(addb_dir, exist_ok=True)
+
         # Create rgw crash file directory
         rgw_core_dir = os.path.join(log_path, 'rgw_debug')
         os.makedirs(rgw_core_dir, exist_ok=True)
@@ -157,7 +170,7 @@ class Rgw:
         Log.info('Starting radosgw service.')
         log_file = os.path.join(log_path, f'{const.COMPONENT_NAME}_startup.log')
 
-        RgwService.start(conf, config_file, log_file, motr_trace_dir, rgw_core_dir, index)
+        RgwService.start(conf, config_file, log_file, motr_trace_dir, addb_dir, rgw_core_dir, index)
         Log.info("Started radosgw service.")
 
         return 0

--- a/src/rgw/setup/rgw_service.py
+++ b/src/rgw/setup/rgw_service.py
@@ -27,10 +27,11 @@ class RgwService:
     """Entrypoint class for RGW."""
 
     @staticmethod
-    def start(conf: MappedConf, config_file, log_file, motr_trace_dir, rgw_cwd, index: str = '1',):
+    def start(conf: MappedConf, config_file, log_file, motr_trace_dir, addb_dir, rgw_cwd, index: str = '1',):
         """Start rgw service independently."""
         try:
             os.environ['M0_TRACE_DIR'] = motr_trace_dir
+            os.environ['M0_CLIENT_ADDB_DIR'] = addb_dir
             cmd = os.path.join(INSTALL_PATH, COMPONENT_NAME, 'bin/radosgw_start')
             sys.stdout.flush()
             sys.stderr.flush()


### PR DESCRIPTION
Signed-off-by: Rahul Kumar <rahul.kumar@seagate.com>

# Problem Statement
The addb client logs in rgw container is generating in wrong directory (rgw_debug). This "rgw_debug" directories meant for rgw crash files only. Our expectation, addb client logs should be resides in "addb_files-0x7200000000000001:0x13" directory.

# Design
-  For Bug, required to create an environment variable for addb directories in "rgw_services.py"

# Coding
   Checklist for Author
-  [x] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [x] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [x] JIRA number/GitHub Issue added to PR
- [x] PR is self reviewed
- [x] Jira and state/status is updated and JIRA is updated with PR link
- [x] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
