### PR TITLE
rgw-integration:[CORTX-32705]:Add GC parameters to mini-provisioner

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -16,14 +16,14 @@
     # Enabling cache causes data retrieval inconsistencies for get-object, head-object etc. ref <CORTX-31109>
     rgw cache enabled = false
 
-    # GC configuration paraneters
-    rgw enable gc threads = true
+    # GC configuration parameters
+    rgw enable gc threads = false
     rgw gc obj min wait = 7200        # 2hours
     rgw gc processor period = 3600    # 1hour
     rgw gc max concurrent io = 1
     rgw gc max trim chunk = 256
     rgw gc max objs = 64
-    rgw gc processor max time = 3600  # 1hour TBD
+    rgw gc processor max time = 3600  # 1hour
 
 
     motr layout id = 9

--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -11,14 +11,20 @@
     rgw thread pool size = 10
     rgw max concurrent request = 10
     rgw init timeout = 300
-    rgw gc max objs = 32
-    rgw gc obj min wait = 1800
-    rgw gc processor max time = 3600
-    rgw gc processor period = 3600
     rgw data path = /var/lib/ceph/radosgw/<cluster-id>   # Cluster id of cortx cluster
 
     # Enabling cache causes data retrieval inconsistencies for get-object, head-object etc. ref <CORTX-31109>
     rgw cache enabled = false
+
+    # GC configuration paraneters
+    rgw enable gc threads = true
+    rgw gc obj min wait = 7200        # 2hours
+    rgw gc processor period = 3600    # 1hour
+    rgw gc max concurrent io = 1
+    rgw gc max trim chunk = 256
+    rgw gc max objs = 64
+    rgw gc processor max time = 3600  # 1hour TBD
+
 
     motr layout id = 9
     motr unit size = 1048576

--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -17,7 +17,7 @@
     rgw cache enabled = false
 
     # GC configuration parameters
-    rgw enable gc threads = false
+    rgw enable gc threads = true
     rgw gc obj min wait = 7200        # 2hours
     rgw gc processor period = 3600    # 1hour
     rgw gc max concurrent io = 1

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -108,10 +108,17 @@ SVC_CONFIG_DICT = {}
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} thread pool size'] = f'cortx>{COMPONENT_NAME}>thread_pool_size'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} max concurrent request'] = f'cortx>{COMPONENT_NAME}>max_concurrent_request'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} init timeout'] = f'cortx>{COMPONENT_NAME}>init_timeout'
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max objs'] = f'cortx>{COMPONENT_NAME}>gc_max_objs'
+
+# GC parameters
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} enable gc threads'] = f'cortx>{COMPONENT_NAME}>enable_gc_threads' # new key
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc obj min wait'] = f'cortx>{COMPONENT_NAME}>gc_obj_min_wait'
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor max time'] = f'cortx>{COMPONENT_NAME}>gc_processor_max_time'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor period'] = f'cortx>{COMPONENT_NAME}>gc_processor_period'
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max concurrent io'] = f'cortx>{COMPONENT_NAME}>gc_max_concurrent_io' # new key
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max trim chunk'] = f'cortx>{COMPONENT_NAME}>gc_max_trim_chunk' # new key
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max objs'] = f'cortx>{COMPONENT_NAME}>gc_max_objs'
+
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor max time'] = f'cortx>{COMPONENT_NAME}>gc_processor_max_time' # TBD
+
 
 # MOTR additional parameters in SVC config file.
 SVC_CONFIG_DICT['motr layout id'] = f'cortx>{COMPONENT_NAME}>motr_layout_id'

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -110,14 +110,13 @@ SVC_CONFIG_DICT[f'{COMPONENT_NAME} max concurrent request'] = f'cortx>{COMPONENT
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} init timeout'] = f'cortx>{COMPONENT_NAME}>init_timeout'
 
 # GC parameters
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} enable gc threads'] = f'cortx>{COMPONENT_NAME}>enable_gc_threads' # new key
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} enable gc threads'] = f'cortx>{COMPONENT_NAME}>enable_gc_threads'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc obj min wait'] = f'cortx>{COMPONENT_NAME}>gc_obj_min_wait'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor period'] = f'cortx>{COMPONENT_NAME}>gc_processor_period'
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max concurrent io'] = f'cortx>{COMPONENT_NAME}>gc_max_concurrent_io' # new key
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max trim chunk'] = f'cortx>{COMPONENT_NAME}>gc_max_trim_chunk' # new key
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max concurrent io'] = f'cortx>{COMPONENT_NAME}>gc_max_concurrent_io'
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max trim chunk'] = f'cortx>{COMPONENT_NAME}>gc_max_trim_chunk'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max objs'] = f'cortx>{COMPONENT_NAME}>gc_max_objs'
-
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor max time'] = f'cortx>{COMPONENT_NAME}>gc_processor_max_time' # TBD
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor max time'] = f'cortx>{COMPONENT_NAME}>gc_processor_max_time'
 
 
 # MOTR additional parameters in SVC config file.


### PR DESCRIPTION
Added GC parameters to rgw config.

# GC configuration parameters
rgw enable gc threads = true
rgw gc obj min wait = 7200        # 2hours
rgw gc processor period = 3600    # 1hour
rgw gc max concurrent io = 1
rgw gc max trim chunk = 256
rgw gc max objs = 64
rgw gc processor max time = 3600  # 1hour

Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
