### PR TITLE
CORTX-33999:changed rgw gc obj min wait time to 15 minutes from 2 hours

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -18,7 +18,7 @@
 
     # GC configuration parameters
     rgw enable gc threads = true
-    rgw gc obj min wait = 7200        # 2hours
+    rgw gc obj min wait = 900        # 15 minutes
     rgw gc processor period = 3600    # 1hour
     rgw gc max concurrent io = 1
     rgw gc max trim chunk = 256


### PR DESCRIPTION
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

Changed GC parameter value 
rgw gc obj min wait : 
Old value : 7200 
New value : 900

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
