### PR TITLE
CORTX-33043: Update motr log rotate scripts with proper PVC log path and removing rgw startup log file

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -59,6 +59,9 @@ LOGROTATE_CONF = f'{LOGROTATE_DIR}/radosgw'
 FREQUENCY='hourly'
 CRON_DIR = f'/etc/cron.{FREQUENCY}'
 CRON_LOGROTATE = f'{CRON_DIR}/logrotate'
+M0TRACE_LOG_ROTATE_FILE = f'{CRON_DIR}/m0trace_logrotate.sh'
+ADDB_LOG_ROTATE_FILE = f'{CRON_DIR}/m0addb_logrotate.sh'
+
 REQUIRED_RPMS = ['cortx-hare', 'cortx-py-utils', 'ceph-radosgw']
 ADMIN_PARAMETERS = {'MOTR_ADMIN_FID':'motr admin fid', 'MOTR_ADMIN_ENDPOINT':'motr admin endpoint', 'RGW_FRONTENDS': 'rgw frontends'}
 

--- a/src/rgw/setup/radosgw_start
+++ b/src/rgw/setup/radosgw_start
@@ -2,8 +2,7 @@
 
 INDEX=$1
 CONFIG_FILE=$2
-LOG_FILE=$3
-RGW_CWD=$4
+RGW_CWD=$3
 
 [ -z "$RGW_CWD" ] && RGW_CWD="$PWD"
 

--- a/src/rgw/setup/radosgw_start
+++ b/src/rgw/setup/radosgw_start
@@ -11,6 +11,5 @@ echo "Change RGW CWD to dir $RGW_CWD, to retain core files in there"
 cd $RGW_CWD
 
 set -o pipefail;
-/usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config 2>&1 \
- | while read line; do printf "%s %s\n" "$(date +'[%Y-%m-%d %H:%M:%S,%03N]')" "$line"; done | tee $LOG_FILE
+/usr/bin/radosgw -f --name client.rgw-$INDEX -c $CONFIG_FILE --no-mon-config
 exit $?

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -161,9 +161,8 @@ class Rgw:
         os.makedirs(rgw_core_dir, exist_ok=True)
 
         Log.info('Starting radosgw service.')
-        log_file = os.path.join(log_path, f'{const.COMPONENT_NAME}_startup.log')
 
-        RgwService.start(conf, config_file, log_file, motr_trace_dir, addb_dir, rgw_core_dir, index)
+        RgwService.start(conf, config_file, motr_trace_dir, addb_dir, rgw_core_dir, index)
         Log.info("Started radosgw service.")
 
         return 0

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -844,16 +844,15 @@ class Rgw:
         """"Update correct PVC path of m0trace, addb log directory for motr log rotate script"""
         motr_addb_file_fid = Conf.get(Rgw._conf_idx, const.MOTR_ADMIN_FID_KEY)
         addb_log_dir_path = os.path.join(svc_log_dir, f'addb_files-{motr_addb_file_fid}')
-        addb_log_rotate_script = os.path.join(const.CRON_DIR, 'm0addb_logrotate.sh')
         motr_trace_log_path = os.path.join(svc_log_dir, 'motr_trace_files')
-        motr_trace_rotate_script = os.path.join(const.CRON_DIR, 'm0trace_logrotate.sh')
 
-        if not os.path.exists(addb_log_rotate_script) or not os.path.exists(motr_trace_rotate_script):
+        if not os.path.exists(const.ADDB_LOG_ROTATE_FILE) or \
+            not os.path.exists(const.M0TRACE_LOG_ROTATE_FILE):
             Log.info(f'WARNING:: {const.CRON_DIR} does not has addb/m0trace motr log rotate scripts.')
             return
         # Handle m0trace log rotate script path.
         try:
-            with open(motr_trace_rotate_script, 'r') as f:
+            with open(const.M0TRACE_LOG_ROTATE_FILE, 'r') as f:
                 content = f.read()
             for line in content :
                 if line.startswith("M0TR_M0D_TRACE_DIR="):
@@ -862,15 +861,15 @@ class Rgw:
                    content = content.replace(line, new_line)
                    break
 
-            with open(motr_trace_rotate_script, 'w') as f:
+            with open(const.M0TRACE_LOG_ROTATE_FILE, 'w') as f:
                 f.write(content)
-            Log.info(f'{motr_trace_rotate_script} file updated with log path {motr_trace_log_path}')
+            Log.info(f'{const.M0TRACE_LOG_ROTATE_FILE} file updated with log path {motr_trace_log_path}')
         except Exception as e:
             Log.error(f"Failed to update m0trace log rotation script path. ERROR:{e}")
 
         # Handle addb trace log rotate script path.
         try:
-            with open(addb_log_rotate_script, 'r') as f:
+            with open(const.ADDB_LOG_ROTATE_FILE, 'r') as f:
                 content = f.read()
             for line in content :
                 if line.startswith("ADDB_RECORD_DIR="):
@@ -879,9 +878,9 @@ class Rgw:
                    content = content.replace(line, new_line)
                    break
 
-            with open(addb_log_rotate_script, 'w') as f:
+            with open(const.ADDB_LOG_ROTATE_FILE, 'w') as f:
                 f.write(content)
-            Log.info(f'{addb_log_rotate_script} file updated with log path {addb_log_dir_path}')
+            Log.info(f'{const.ADDB_LOG_ROTATE_FILE} file updated with log path {addb_log_dir_path}')
         except Exception as e:
             Log.error(f"Failed to update m0addb log rotation script path. ERROR:{e}")
 

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -857,14 +857,15 @@ class Rgw:
         # Handle m0trace log rotate script path.
         try:
             with open(const.M0TRACE_LOG_ROTATE_FILE, 'r') as f:
-                lines=f.readlines()
+                lines = f.readlines()
             tmp_file = "/tmp/tmp_m0trace.sh"
-            with open(tmp_file, 'w') as tmp_file:
-                for line in lines :
+            with open(tmp_file, 'w') as tmp_fout:
+                for idx, line in enumerate(lines):
                     if line.startswith("M0TR_M0D_TRACE_DIR="):
-                       trace_dir_val = line.split("=")[1]
-                       line = line.replace(trace_dir_val, motr_trace_log_path)
-                    tmp_file.write(line)
+                       trace_key_name = line.split("=")[0]
+                       updated_line = trace_key_name + "=" + f'\"{motr_trace_log_path}\"' + "\n"
+                       lines[idx] = updated_line
+                    tmp_fout.write(lines[idx])
 
             shutil.copyfile(tmp_file, const.M0TRACE_LOG_ROTATE_FILE)
             os.remove(tmp_file)
@@ -875,14 +876,15 @@ class Rgw:
         # Handle addb trace log rotate script path.
         try:
             with open(const.ADDB_LOG_ROTATE_FILE, 'r') as f:
-                lines=f.readlines()
+                lines = f.readlines()
             tmp_file = "/tmp/tmp_m0addb_log.sh"
-            with open(tmp_file, 'w') as tmp_file:
-                for line in lines :
+            with open(tmp_file, 'w') as tmp_fout:
+                for idx, line in enumerate(lines):
                     if line.startswith("ADDB_RECORD_DIR="):
-                       addb_dir_val = line.split("=")[1]
-                       line = line.replace(addb_dir_val, addb_log_dir_path)
-                    tmp_file.write(line)
+                       addb_dir_key = line.split("=")[0]
+                       updated_line = addb_dir_key + "=" + f'\"{addb_log_dir_path}\"' + "\n"
+                       lines[idx] = updated_line
+                    tmp_fout.write(lines[idx])
 
             shutil.copyfile(tmp_file, const.ADDB_LOG_ROTATE_FILE)
             os.remove(tmp_file)

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -858,7 +858,7 @@ class Rgw:
         try:
             with open(const.M0TRACE_LOG_ROTATE_FILE, 'r') as f:
                 lines = f.readlines()
-            tmp_file = os.path.join('/tmp', 'tmp_m0trace.sh')
+            tmp_file = os.path.join(const.CRON_DIR, 'tmp_m0trace.sh')
             with open(tmp_file, 'w') as tmp_fout:
                 for idx, line in enumerate(lines):
                     if line.startswith("M0TR_M0D_TRACE_DIR="):
@@ -877,7 +877,7 @@ class Rgw:
         try:
             with open(const.ADDB_LOG_ROTATE_FILE, 'r') as f:
                 lines = f.readlines()
-            tmp_file = os.path.join('/tmp', 'tmp_m0addb_log.sh')
+            tmp_file = os.path.join(const.CRON_DIR, 'tmp_m0addb_log.sh')
             with open(tmp_file, 'w') as tmp_fout:
                 for idx, line in enumerate(lines):
                     if line.startswith("ADDB_RECORD_DIR="):

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -858,7 +858,7 @@ class Rgw:
         try:
             with open(const.M0TRACE_LOG_ROTATE_FILE, 'r') as f:
                 lines = f.readlines()
-            tmp_file = "/tmp/tmp_m0trace.sh"
+            tmp_file = os.path.join('/tmp', 'tmp_m0trace.sh')
             with open(tmp_file, 'w') as tmp_fout:
                 for idx, line in enumerate(lines):
                     if line.startswith("M0TR_M0D_TRACE_DIR="):
@@ -877,7 +877,7 @@ class Rgw:
         try:
             with open(const.ADDB_LOG_ROTATE_FILE, 'r') as f:
                 lines = f.readlines()
-            tmp_file = "/tmp/tmp_m0addb_log.sh"
+            tmp_file = os.path.join('/tmp', 'tmp_m0addb_log.sh')
             with open(tmp_file, 'w') as tmp_fout:
                 for idx, line in enumerate(lines):
                     if line.startswith("ADDB_RECORD_DIR="):

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -842,6 +842,10 @@ class Rgw:
     @staticmethod
     def _update_motr_log_rotate_scripts(conf: MappedConf, svc_log_dir: str):
         """"Update correct PVC path of m0trace, addb log directory for motr log rotate script"""
+        config_file = Rgw._get_rgw_config_path(conf)
+        confstore_url = const.CONFSTORE_FILE_HANDLER + config_file
+        Rgw._load_rgw_config(Rgw._conf_idx, confstore_url)
+
         motr_addb_file_fid = Conf.get(Rgw._conf_idx, const.MOTR_ADMIN_FID_KEY)
         addb_log_dir_path = os.path.join(svc_log_dir, f'addb_files-{motr_addb_file_fid}')
         motr_trace_log_path = os.path.join(svc_log_dir, 'motr_trace_files')

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -857,16 +857,17 @@ class Rgw:
         # Handle m0trace log rotate script path.
         try:
             with open(const.M0TRACE_LOG_ROTATE_FILE, 'r') as f:
-                content = f.read()
-            for line in content :
-                if line.startswith("M0TR_M0D_TRACE_DIR="):
-                   line_key = line.split("=")[0]
-                   new_line = line_key + "=" + motr_trace_log_path
-                   content = content.replace(line, new_line)
-                   break
+                lines=f.readlines()
+            tmp_file = "/tmp/tmp_m0trace.sh"
+            with open(tmp_file, 'w') as tmp_file:
+                for line in lines :
+                    if line.startswith("M0TR_M0D_TRACE_DIR="):
+                       trace_dir_val = line.split("=")[1]
+                       line = line.replace(trace_dir_val, motr_trace_log_path)
+                    tmp_file.write(line)
 
-            with open(const.M0TRACE_LOG_ROTATE_FILE, 'w') as f:
-                f.write(content)
+            shutil.copyfile(tmp_file, const.M0TRACE_LOG_ROTATE_FILE)
+            os.remove(tmp_file)
             Log.info(f'{const.M0TRACE_LOG_ROTATE_FILE} file updated with log path {motr_trace_log_path}')
         except Exception as e:
             Log.error(f"Failed to update m0trace log rotation script path. ERROR:{e}")
@@ -874,16 +875,18 @@ class Rgw:
         # Handle addb trace log rotate script path.
         try:
             with open(const.ADDB_LOG_ROTATE_FILE, 'r') as f:
-                content = f.read()
-            for line in content :
-                if line.startswith("ADDB_RECORD_DIR="):
-                   line_key = line.split("=")[0]
-                   new_line = line_key + "=" + addb_log_dir_path
-                   content = content.replace(line, new_line)
-                   break
+                lines=f.readlines()
+            tmp_file = "/tmp/tmp_m0addb_log.sh"
+            with open(tmp_file, 'w') as tmp_file:
+                for line in lines :
+                    if line.startswith("ADDB_RECORD_DIR="):
+                       addb_dir_val = line.split("=")[1]
+                       line = line.replace(addb_dir_val, addb_log_dir_path)
+                    tmp_file.write(line)
 
-            with open(const.ADDB_LOG_ROTATE_FILE, 'w') as f:
-                f.write(content)
+            shutil.copyfile(tmp_file, const.ADDB_LOG_ROTATE_FILE)
+            os.remove(tmp_file)
+
             Log.info(f'{const.ADDB_LOG_ROTATE_FILE} file updated with log path {addb_log_dir_path}')
         except Exception as e:
             Log.error(f"Failed to update m0addb log rotation script path. ERROR:{e}")

--- a/src/rgw/setup/rgw_service.py
+++ b/src/rgw/setup/rgw_service.py
@@ -27,7 +27,7 @@ class RgwService:
     """Entrypoint class for RGW."""
 
     @staticmethod
-    def start(conf: MappedConf, config_file, log_file, motr_trace_dir, addb_dir, rgw_cwd, index: str = '1',):
+    def start(conf: MappedConf, config_file, motr_trace_dir, addb_dir, rgw_cwd, index: str = '1',):
         """Start rgw service independently."""
         try:
             os.environ['M0_TRACE_DIR'] = motr_trace_dir
@@ -35,7 +35,7 @@ class RgwService:
             cmd = os.path.join(INSTALL_PATH, COMPONENT_NAME, 'bin/radosgw_start')
             sys.stdout.flush()
             sys.stderr.flush()
-            os.execl(cmd, cmd, index, config_file, log_file, rgw_cwd)
+            os.execl(cmd, cmd, index, config_file, rgw_cwd)
         except OSError as e:
             Log.error(f"Failed to start radosgw service:{e}")
             raise SetupError(e.errno, "Failed to start radosgw service. %s", e)


### PR DESCRIPTION
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- While starting rgw service, we redirect all the logs to one file which captures all the motr, gc logs to this file.
With latest changes, these logs are already captured hence we don't need to dump into the log file. hence removing this file itself.
- Update m0trace, m0addb log rotation scripts present in /etc/cron.hourly with proper PVC path where motr client logs are stored in rgw container.

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
