### PR TITLE
CORTX-33944:Disabling RGW service console logging to address performance issue

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -52,5 +52,5 @@
     rgw frontends = beast port=8000
     log file =
     log to file = true
-    log to stderr = true
-    err to stderr = true
+    log to stderr = false
+    err to stderr = false


### PR DESCRIPTION
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement
Observed performance impact if we enable rgw logging on console. 

- Solution
Disable logging messages for rgw service to console.
[client.rgw-1]
  log to file = true
  log to stderr = false
  err to stderr = false
# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
