### PR TITLE
[CORTX-34109] Updated rgw log level default value and exposed it to solution.yaml

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -1,5 +1,5 @@
 [global]
-    debug rgw = 20
+    debug rgw = 10
 
 [client]
     rgw backend store = motr

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -129,7 +129,6 @@ SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max trim chunk'] = f'cortx>{COMPONENT_NAME
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc max objs'] = f'cortx>{COMPONENT_NAME}>gc_max_objs'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc processor max time'] = f'cortx>{COMPONENT_NAME}>gc_processor_max_time'
 
-
 # MOTR additional parameters in SVC config file.
 SVC_CONFIG_DICT['motr layout id'] = f'cortx>{COMPONENT_NAME}>motr_layout_id'
 SVC_CONFIG_DICT['motr unit size'] = f'cortx>{COMPONENT_NAME}>motr_unit_size'
@@ -140,6 +139,9 @@ SVC_CONFIG_DICT['motr reconnect interval'] = f'cortx>{COMPONENT_NAME}>motr_recon
 SVC_CONFIG_DICT['motr reconnect retry count'] = f'cortx>{COMPONENT_NAME}>motr_reconnect_retry_count'
 SVC_CONFIG_DICT['motr addb enabled'] = f'cortx>{COMPONENT_NAME}>motr_addb_enabled'
 
+# RGW LOG parameters
+SVC_LOG_CONFIG_DICT = {}
+SVC_LOG_CONFIG_DICT[f'debug {COMPONENT_NAME}'] = f'cortx>{COMPONENT_NAME}>log_level'
 
 SVC_DATA_PATH_CONFSTORE_KEY = f'cortx>{COMPONENT_NAME}>data_path'
 SVC_DATA_PATH_KEY = f'{COMPONENT_NAME} data path'

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -302,6 +302,7 @@ class Rgw:
 
         # Add additional parameters of SVC & Motr to config file.
         Rgw._update_svc_config(conf, 'client', const.SVC_CONFIG_DICT)
+        Rgw._update_svc_config(conf, 'global', const.SVC_LOG_CONFIG_DICT)
         Rgw._update_svc_data_path_value(conf, 'client')
 
         Rgw._update_resource_limit_based_config(conf, 'client')


### PR DESCRIPTION
Signed-off-by: Priyanka Salunke <priyanka.s.salunke@seagate.com>

# Problem Statement
- Updated default value and exposed the log level value : `default log level - 10`
- Exposed the config parameters to solution.yaml file : `cortx>rgw>log_level`
- Example:
```
s3:
....
     extra_configuration: |
          log_level: 30
```
# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
