### PR TITLE
CORTX-34161: exposing thread_pool_size & max_concurrent_requests parameters in solution.yaml for rgw

### DIFF
--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -120,7 +120,6 @@ SVC_CONFIG_DICT = {}
 
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} init timeout'] = f'cortx>{COMPONENT_NAME}>init_timeout'
 
-
 # GC parameters
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} enable gc threads'] = f'cortx>{COMPONENT_NAME}>enable_gc_threads'
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} gc obj min wait'] = f'cortx>{COMPONENT_NAME}>gc_obj_min_wait'

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -119,6 +119,8 @@ SVC_ENDPOINT_VALUE_KEY = f'{SVC_ENDPOINT}>endpoints[%s]'
 SVC_CONFIG_DICT = {}
 
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} init timeout'] = f'cortx>{COMPONENT_NAME}>init_timeout'
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} thread pool size'] = f'cortx>{COMPONENT_NAME}>thread_pool_size'
+SVC_CONFIG_DICT[f'{COMPONENT_NAME} max concurrent requests'] = f'cortx>{COMPONENT_NAME}>max_concurrent_requests'
 
 # GC parameters
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} enable gc threads'] = f'cortx>{COMPONENT_NAME}>enable_gc_threads'

--- a/src/rgw/const.py
+++ b/src/rgw/const.py
@@ -119,8 +119,7 @@ SVC_ENDPOINT_VALUE_KEY = f'{SVC_ENDPOINT}>endpoints[%s]'
 SVC_CONFIG_DICT = {}
 
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} init timeout'] = f'cortx>{COMPONENT_NAME}>init_timeout'
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} thread pool size'] = f'cortx>{COMPONENT_NAME}>thread_pool_size'
-SVC_CONFIG_DICT[f'{COMPONENT_NAME} max concurrent requests'] = f'cortx>{COMPONENT_NAME}>max_concurrent_requests'
+
 
 # GC parameters
 SVC_CONFIG_DICT[f'{COMPONENT_NAME} enable gc threads'] = f'cortx>{COMPONENT_NAME}>enable_gc_threads'
@@ -184,6 +183,8 @@ CPU_VAL_MULTIPLICATION_FACTOR = 1000
 SVC_RESOURCE_LIMIT_CPU_VAL_SIZE_MAP = { "m": 1 }
 SVC_THREAD_POOL_SIZE_KEY = f'{COMPONENT_NAME} thread pool size'
 SVC_CONCURRENT_MAX_REQ_KEY = f'{COMPONENT_NAME} max concurrent requests'
+GCONF_THREAD_POOL_SIZE_KEY = f'cortx>{COMPONENT_NAME}>thread_pool_size'
+GCONF_MAX_CONCURRENT_REQ_KEY = f'cortx>{COMPONENT_NAME}>max_concurrent_requests'
 
 # Support Bundle
 SVC_FILE_PERCENTAGE = 95

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -305,7 +305,7 @@ class Rgw:
         Rgw._update_svc_config(conf, 'global', const.SVC_LOG_CONFIG_DICT)
         Rgw._update_svc_data_path_value(conf, 'client')
 
-        Rgw._update_resource_limit_based_config(conf, 'client')
+        #Rgw._update_resource_limit_based_config(conf, 'client')
         # Before user creation,Verify backend store value=motr in rgw config file.
         Rgw._verify_backend_store_value(conf)
 

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -306,7 +306,6 @@ class Rgw:
         Rgw._update_svc_data_path_value(conf, 'client')
 
         Rgw._update_resource_limit_based_config(conf, 'client')
-
         # Before user creation,Verify backend store value=motr in rgw config file.
         Rgw._verify_backend_store_value(conf)
 
@@ -1056,7 +1055,6 @@ class Rgw:
     def _update_resource_limit_based_config(conf: MappedConf, client_section: str):
         """Update svc config file with 'thread pool size' & 'concurrent max req' key based on
         resource limit formula."""
-
         svc_config_file = Rgw._get_rgw_config_path(conf)
         confstore_url = const.CONFSTORE_FILE_HANDLER + svc_config_file
         Rgw._load_rgw_config(Rgw._conf_idx, confstore_url)

--- a/src/rgw/setup/rgw.py
+++ b/src/rgw/setup/rgw.py
@@ -1108,7 +1108,7 @@ class Rgw:
         if thread_pool_size_val is None:
             thread_pool_size_val = math.floor(min(tuned_memory_val, tuned_cpu_val))
 
-        if thread_pool_size_val > 0 :
+        if int(thread_pool_size_val) > 0 :
            Log.debug(f'Setting KV pair {const.SVC_THREAD_POOL_SIZE_KEY} : {thread_pool_size_val}'
                f'at {client_section} section')
            Conf.set(Rgw._conf_idx, f'{client_section}>{const.SVC_THREAD_POOL_SIZE_KEY}',
@@ -1117,7 +1117,7 @@ class Rgw:
            raise SetupError(errno.EINVAL,
                             'Invalid value is generated for {const.SVC_THREAD_POOL_SIZE_KEY} key.')
 
-        if concurrent_max_requests_val > 0 :
+        if int(concurrent_max_requests_val) > 0 :
            Log.debug(f'Setting KV pair {const.SVC_CONCURRENT_MAX_REQ_KEY} :'
                      f'{concurrent_max_requests_val} at {client_section} section')
            Conf.set(Rgw._conf_idx, f'{client_section}>{const.SVC_CONCURRENT_MAX_REQ_KEY}',


### PR DESCRIPTION
If user provide any of these parameters in solution.yaml file then we will skip resource limit based formula calculation and we will pick up user specified value.
if solution.yaml file does not has these keys in extra_configuration section then we will generate values using resource limit based formula.

example soultion.yaml ,

"
   s3:
      default_iam_users:
        auth_admin: sgiamadmin
        auth_user: user_name
      max_start_timeout: 240
      instances_per_node: '1'
      extra_configuration: |
        thread_pool_size: 30
        max_concurrent_requests: 33
        enable_gc_threads: 'false'
"
Signed-off-by: Sachitanand Shelake <sachitanand.shelake@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
