### PR TITLE
CORTX-30240: Enabling back RGW stdout/stderr logging after confirming IO tests performance results

### DIFF
--- a/conf/cortx_rgw.conf
+++ b/conf/cortx_rgw.conf
@@ -52,5 +52,5 @@
     rgw frontends = beast port=8000
     log file =
     log to file = true
-    log to stderr = false
-    err to stderr = false
+    log to stderr = true
+    err to stderr = true


### PR DESCRIPTION
Enabled back RGW stdout/stderr logging

Signed-off-by: Chetan S. Deshmukh <chetan.deshmukh@seagate.com>

# Problem Statement
- RGW stdout/stderr logging was disabled owing to performance regression reported in CORTX-33944

# Design
- After [this change](https://github.com/Seagate/cortx-rgw-integration/pull/124/files#diff-41d93f02c5a69a10187e14688fce682f63a6b77a5e80f9aae86c659fcf35e742R13) was merged, perf issue was resolved, removing code which was reading libMotr log o/p line by line, and prepending timestamp & then pushing it to stdout/stderr


# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
